### PR TITLE
Document panics for zero or negative step in Interval iterators

### DIFF
--- a/crates/dock-alloc-core/src/primitives.rs
+++ b/crates/dock-alloc-core/src/primitives.rs
@@ -408,7 +408,7 @@ impl<T> Interval<T> {
     ///
     /// # Panics
     ///
-    /// If `step` is zero or negative, this method will panic.
+    /// This method will panic immediately if `step` is zero or negative.
     ///
     /// # Examples
     ///

--- a/crates/dock-alloc-core/src/primitives.rs
+++ b/crates/dock-alloc-core/src/primitives.rs
@@ -515,7 +515,7 @@ impl<'a, T: Copy + PartialOrd + Zero> IntervalIter<'a, T> {
     ///
     /// # Panics
     ///
-    /// If `step` is zero or negative, this method will panic.
+    /// This method will panic immediately if `step` is zero or negative.
     fn new(interval: &'a Interval<T>, step: T) -> Self {
         assert!(step > T::zero(), "Interval::iter: step must be > 0");
 

--- a/crates/dock-alloc-core/src/primitives.rs
+++ b/crates/dock-alloc-core/src/primitives.rs
@@ -406,6 +406,10 @@ impl<T> Interval<T> {
     /// starting from `start_inclusive` and incrementing by `step`
     /// until it reaches or exceeds `end_exclusive`.
     ///
+    /// # Panics
+    ///
+    /// If `step` is zero or negative, this method will panic.
+    ///
     /// # Examples
     ///
     /// ```
@@ -508,6 +512,10 @@ impl<'a, T: Copy + PartialOrd + Zero> IntervalIter<'a, T> {
     ///
     /// This method initializes the iterator with the starting point as `start_inclusive`
     /// and sets the step size for each iteration.
+    ///
+    /// # Panics
+    ///
+    /// If `step` is zero or negative, this method will panic.
     fn new(interval: &'a Interval<T>, step: T) -> Self {
         assert!(step > T::zero(), "Interval::iter: step must be > 0");
 


### PR DESCRIPTION
This pull request adds important documentation updates to clarify the behavior of interval iteration methods, specifically regarding panic conditions when an invalid step value is provided.