### PR TITLE
Feature/create model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dock_alloc_model"
+version = "0.1.0"
+dependencies = [
+ "dock_alloc_core",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/dock-alloc-core/README.md
+++ b/crates/dock-alloc-core/README.md
@@ -1,0 +1,64 @@
+# Dock Allocation Core (`dock-alloc-core`)
+
+A foundational Rust crate providing robust, type-safe primitives for the **Berth Allocation Problem (BAP)**.
+
+`dock-alloc-core` is the bedrock of the Dock Allocation project. It establishes a strong data model for the two primary domains of the problem—**time** and **space**—to prevent common logical errors at compile time.
+
+---
+
+## Core Concepts
+
+The library's design revolves around the newtype pattern to create distinct, non-interchangeable types for different domain concepts. This means you can't accidentally add a `TimePoint` to another `TimePoint`, or a `SpacePosition` to another `SpacePosition`, which helps ensure logical correctness throughout your application.
+
+### Time Domain
+
+* **`TimePoint<T>`**: Represents a specific, absolute point in time (e.g., an arrival timestamp).
+* **`TimeDelta<T>`**: Represents a duration or the difference between two time points (e.g., handling time).
+* **`TimeInterval<T>`**: A half-open interval `[start, end)` composed of two `TimePoint`s, representing a time window.
+
+### Space Domain
+
+* **`SpacePosition`**: Represents a discrete position along a one-dimensional space (e.g., a quay).
+* **`SpaceLength`**: Represents a length or size, such as that of a vessel or a quay segment.
+* **`SpaceInterval`**: A half-open interval `[start, end)` representing a contiguous section of space.
+
+---
+
+## Features
+
+* **Type Safety**: Prevents incorrect operations between different domain types at compile time.
+* **Robust Arithmetic**: All types implement standard arithmetic traits (`+`, `-`, `*`, `/`) with both panicking and safe (`checked_`, `saturating_`) versions to handle overflow and underflow gracefully.
+* **Ergonomic API**: Includes convenient methods like `.span_of()` to create intervals and `Sum` implementations for easy aggregation.
+* **Comprehensive Documentation**: Every public function is documented with clear explanations and examples.
+* **Thoroughly Tested**: A full suite of unit tests covers functionality, edge cases, and panic conditions.
+
+---
+
+## Usage
+
+Here is a basic example of how to model a ship's allocation on a quay using the types from this crate.
+
+```rust
+use dock_alloc_core::domain::{TimePoint, TimeDelta, SpacePosition, SpaceLength};
+
+fn main() {
+    // Define a time window for the ship's stay.
+    let arrival_time = TimePoint::new(100_i64);
+    let handling_duration = TimeDelta::new(50_i64);
+    let time_window = arrival_time.span_of(handling_duration).unwrap();
+
+    // Define the space required by the ship.
+    let berth_position = SpacePosition::new(20);
+    let ship_length = SpaceLength::new(15);
+    let space_interval = berth_position.span_of(ship_length).unwrap();
+
+    println!(
+        "Ship is allocated from {} to {} at positions {} to {}.",
+        time_window.start(),
+        time_window.end(),
+        space_interval.start(),
+        space_interval.end()
+    );
+    // Output: Ship is allocated from TimePoint(100) to TimePoint(150) at positions SpacePosition(20) to SpacePosition(35).
+}
+```

--- a/crates/dock-alloc-core/README.md
+++ b/crates/dock-alloc-core/README.md
@@ -22,6 +22,10 @@ The library's design revolves around the newtype pattern to create distinct, non
 * **`SpaceLength`**: Represents a length or size, such as that of a vessel or a quay segment.
 * **`SpaceInterval`**: A half-open interval `[start, end)` representing a contiguous section of space.
 
+### Cost Domain
+
+* **`Cost<T>`**: Represents a cost associated with an allocation, such as the time or space used by a ship.
+
 ---
 
 ## Features

--- a/crates/dock-alloc-core/src/domain.rs
+++ b/crates/dock-alloc-core/src/domain.rs
@@ -2398,6 +2398,7 @@ impl Interval<SpacePosition> {
     }
 }
 
+#[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Cost<T>(T);
 

--- a/crates/dock-alloc-core/src/domain.rs
+++ b/crates/dock-alloc-core/src/domain.rs
@@ -23,7 +23,7 @@
 //!
 //! This module provides the fundamental data types for modeling the Berth Allocation Problem (BAP).
 //! It establishes a strong, type-safe foundation for representing the two primary domains
-//! of the problem: **time** and **quay space**.
+//! of the problem: **time** and **space**.
 //!
 //! ## Key Concepts
 //!
@@ -32,10 +32,10 @@
 //!   - `TimeDelta<T>`: Represents a duration or the difference between two time points.
 //!   - `TimeInterval<T>`: A half-open interval `[start, end)` composed of two `TimePoint`s.
 //!
-//! - **Quay Space**:
-//!   - `QuayPosition`: Represents a discrete position along the quay.
-//!   - `QuayLength`: Represents a length or size, such as that of a vessel.
-//!   - `QuayInterval`: A half-open interval `[start, end)` representing a contiguous section of the quay.
+//! - **Space**:
+//!   - `SpacePosition`: Represents a discrete position along the quay.
+//!   - `SpaceLength`: Represents a length or size, such as that of a vessel.
+//!   - `SpaceInterval`: A half-open interval `[start, end)` representing a contiguous section of the quay.
 //!
 //! The use of distinct newtypes enforces correctness at compile time—for example,
 //! preventing the addition of two `TimePoint`s.
@@ -1073,131 +1073,130 @@ impl<'a, T: PrimInt + Signed> Sum<&'a TimeDelta<T>> for TimeDelta<T> {
     }
 }
 
-/// Represents a position along a quay.
+/// Represents a position along a one-dimensional space (e.g., a quay).
 ///
-/// A `QuayPosition` is a wrapper around a primitive unsigned integer type
-/// that represents a position along a quay.
+/// A `SpacePosition` is a wrapper around a primitive unsigned integer type
+/// that represents a specific position along a quay or similar structure.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_core::domain::QuayPosition;
+/// use dock_alloc_core::domain::SpacePosition;
 ///
-/// let seg_idx = QuayPosition::new(5);
-/// assert_eq!(seg_idx.value(), 5);
-/// assert_eq!(format!("{}", seg_idx), "QuayPosition(5)");
+/// let pos = SpacePosition::new(5);
+/// assert_eq!(pos.value(), 5);
+/// assert_eq!(format!("{}", pos), "SpacePosition(5)");
 /// ```
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct QuayPosition(usize);
+pub struct SpacePosition(usize);
 
-/// Represents an interval along a quay.
+/// Represents a contiguous half-open interval `[start, end)` along the space.
 ///
-/// A `QuayInterval` is a half-open interval defined by a start and end `QuayPosition`.
-/// It represents a contiguous section of the quay, where the start index is inclusive
-/// and the end index is exclusive.
+/// A `SpaceInterval` is a half-open interval defined by a start and end `SpacePosition`.
+/// It represents a contiguous segment of space, such as a section of a quay.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_core::domain::{QuayPosition, QuayInterval, QuayLength};
+/// use dock_alloc_core::domain::{SpacePosition, SpaceInterval, SpaceLength};
 ///
-/// let start = QuayPosition::new(5);
-/// let length = QuayLength::new(10);
+/// let start = SpacePosition::new(5);
+/// let length = SpaceLength::new(10);
 ///
 /// let span = start.span_of(length);
 /// assert_eq!(span.unwrap().start().value(), 5);
 /// assert_eq!(span.unwrap().end().value(), 15);
 /// ```
-pub type QuayInterval = Interval<QuayPosition>;
+pub type SpaceInterval = Interval<SpacePosition>;
 
-impl Display for QuayPosition {
-    /// Formats the `QuayPosition` as `QuayPosition(value)`.
+impl Display for SpacePosition {
+    /// Formats the `SpacePosition` as `SpacePosition(value)`.
     ///
-    /// Formats the `QuayPosition` instance as a string in the format `QuayPosition(value)`,
-    /// where `value` is the inner value of the `QuayPosition`.
+    /// Formats the `SpacePosition` instance as a string in the format `SpacePosition(value)`,
+    /// where `value` is the inner value of the `SpacePosition`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayPosition;
+    /// use dock_alloc_core::domain::SpacePosition;
     ///
-    /// let seg_idx = QuayPosition::new(5);
-    /// assert_eq!(format!("{}", seg_idx), "QuayPosition(5)");
+    /// let pos = SpacePosition::new(5);
+    /// assert_eq!(format!("{}", pos), "SpacePosition(5)");
     /// ```
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "QuayPosition({})", self.0)
+        write!(f, "SpacePosition({})", self.0)
     }
 }
 
-impl From<usize> for QuayPosition {
-    /// Converts a primitive unsigned integer type into a `QuayPosition`.
+impl From<usize> for SpacePosition {
+    /// Converts a primitive unsigned integer type into a `SpacePosition`.
     ///
     /// This implementation allows for easy conversion from a primitive unsigned integer type
-    /// to a `QuayPosition`, enabling the use of `QuayPosition`
+    /// to a `SpacePosition`, enabling the use of `SpacePosition`
     /// in contexts where a primitive unsigned integer is available.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayPosition;
+    /// use dock_alloc_core::domain::SpacePosition;
     ///
     /// let value: usize = 5;
-    /// let seg_idx: QuayPosition = QuayPosition::from(value);
-    /// assert_eq!(seg_idx.value(), 5);
+    /// let pos: SpacePosition = SpacePosition::from(value);
+    /// assert_eq!(pos.value(), 5);
     /// ```
     #[inline]
     fn from(v: usize) -> Self {
-        QuayPosition(v)
+        SpacePosition(v)
     }
 }
 
-impl QuayPosition {
-    /// Creates a new `QuayPosition` with the given value.
+impl SpacePosition {
+    /// Creates a new `SpacePosition` with the given value.
     ///
-    /// Creates a new `QuayPosition` instance wrapping the provided `usize` value.
+    /// Creates a new `SpacePosition` instance wrapping the provided `usize` value.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayPosition;
+    /// use dock_alloc_core::domain::SpacePosition;
     ///
-    /// let pos = QuayPosition::new(5);
+    /// let pos = SpacePosition::new(5);
     /// assert_eq!(pos.value(), 5);
     /// ```
     #[inline(always)]
     pub const fn new(v: usize) -> Self {
-        QuayPosition(v)
+        SpacePosition(v)
     }
 
-    /// Creates a new `QuayPosition` with a value of zero.
+    /// Creates a new `SpacePosition` with a value of zero.
     ///
-    /// This is a convenient way to get a `QuayPosition` representing the start of the quay.
+    /// This is a convenient way to get a `SpacePosition` representing the start of the quay.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayPosition;
+    /// use dock_alloc_core::domain::SpacePosition;
     ///
-    /// let pos = QuayPosition::zero();
+    /// let pos = SpacePosition::zero();
     /// assert_eq!(pos.value(), 0);
     /// ```
     #[inline(always)]
     pub const fn zero() -> Self {
-        QuayPosition(0)
+        SpacePosition(0)
     }
 
-    /// Returns the inner value of the `QuayPosition`.
+    /// Returns the inner value of the `SpacePosition`.
     ///
-    /// Extracts the primitive `usize` value from the `QuayPosition` wrapper.
+    /// Extracts the primitive `usize` value from the `SpacePosition` wrapper.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayPosition;
+    /// use dock_alloc_core::domain::SpacePosition;
     ///
-    /// let pos = QuayPosition::new(5);
+    /// let pos = SpacePosition::new(5);
     /// assert_eq!(pos.value(), 5);
     /// ```
     #[inline(always)]
@@ -1205,17 +1204,17 @@ impl QuayPosition {
         self.0
     }
 
-    /// Checks if the `QuayPosition` is zero.
+    /// Checks if the `SpacePosition` is zero.
     ///
     /// Returns `true` if the position is at the start of the quay (value is 0).
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayPosition;
+    /// use dock_alloc_core::domain::SpacePosition;
     ///
-    /// assert!(QuayPosition::zero().is_zero());
-    /// assert!(!QuayPosition::new(1).is_zero());
+    /// assert!(SpacePosition::zero().is_zero());
+    /// assert!(!SpacePosition::new(1).is_zero());
     /// ```
     #[inline(always)]
     pub const fn is_zero(self) -> bool {
@@ -1229,14 +1228,14 @@ impl QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let pos = QuayPosition::new(usize::MAX);
-    /// assert!(pos.checked_add(QuayLength::new(1)).is_none());
+    /// let pos = SpacePosition::new(usize::MAX);
+    /// assert!(pos.checked_add(SpaceLength::new(1)).is_none());
     /// ```
     #[inline]
-    pub fn checked_add(self, len: QuayLength) -> Option<Self> {
-        self.0.checked_add(len.0).map(QuayPosition)
+    pub fn checked_add(self, len: SpaceLength) -> Option<Self> {
+        self.0.checked_add(len.0).map(SpacePosition)
     }
 
     /// Computes `self - len`, returning `None` if underflow occurred.
@@ -1246,50 +1245,50 @@ impl QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let pos = QuayPosition::new(5);
-    /// assert!(pos.checked_sub(QuayLength::new(10)).is_none());
+    /// let pos = SpacePosition::new(5);
+    /// assert!(pos.checked_sub(SpaceLength::new(10)).is_none());
     /// ```
     #[inline]
-    pub fn checked_sub(self, len: QuayLength) -> Option<Self> {
-        self.0.checked_sub(len.0).map(QuayPosition)
+    pub fn checked_sub(self, len: SpaceLength) -> Option<Self> {
+        self.0.checked_sub(len.0).map(SpacePosition)
     }
 
     /// Saturating addition. Computes `self + len`, saturating at the numeric bounds.
     ///
-    /// Performs an addition that returns `QuayPosition(usize::MAX)` if the result would overflow.
+    /// Performs an addition that returns `SpacePosition(usize::MAX)` if the result would overflow.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let pos = QuayPosition::new(usize::MAX - 2);
-    /// let result = pos.saturating_add(QuayLength::new(5));
+    /// let pos = SpacePosition::new(usize::MAX - 2);
+    /// let result = pos.saturating_add(SpaceLength::new(5));
     /// assert_eq!(result.value(), usize::MAX);
     /// ```
     #[inline]
-    pub fn saturating_add(self, len: QuayLength) -> Self {
-        QuayPosition(self.0.saturating_add(len.0))
+    pub fn saturating_add(self, len: SpaceLength) -> Self {
+        SpacePosition(self.0.saturating_add(len.0))
     }
 
     /// Saturating subtraction. Computes `self - len`, saturating at zero.
     ///
-    /// Performs a subtraction that returns `QuayPosition(0)` if the result would be negative.
+    /// Performs a subtraction that returns `SpacePosition(0)` if the result would be negative.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let pos = QuayPosition::new(5);
-    /// let result = pos.saturating_sub(QuayLength::new(10));
+    /// let pos = SpacePosition::new(5);
+    /// let result = pos.saturating_sub(SpaceLength::new(10));
     /// assert_eq!(result.value(), 0);
     /// ```
     #[inline]
-    pub fn saturating_sub(self, len: QuayLength) -> Self {
-        QuayPosition(self.0.saturating_sub(len.0))
+    pub fn saturating_sub(self, len: SpaceLength) -> Self {
+        SpacePosition(self.0.saturating_sub(len.0))
     }
 
     /// Creates a half-open interval `[self, self + len)`.
@@ -1299,29 +1298,29 @@ impl QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength, QuayInterval};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength, SpaceInterval};
     ///
-    /// let start = QuayPosition::new(10);
-    /// let length = QuayLength::new(20);
+    /// let start = SpacePosition::new(10);
+    /// let length = SpaceLength::new(20);
     /// let interval = start.span_of(length).unwrap();
     ///
     /// assert_eq!(interval.start(), start);
-    /// assert_eq!(interval.end(), QuayPosition::new(30));
+    /// assert_eq!(interval.end(), SpacePosition::new(30));
     /// ```
     #[inline]
-    pub fn span_of(self, len: QuayLength) -> Option<QuayInterval> {
+    pub fn span_of(self, len: SpaceLength) -> Option<SpaceInterval> {
         self.checked_add(len)
-            .map(|end| QuayInterval::new(self, end))
+            .map(|end| SpaceInterval::new(self, end))
     }
 }
 
-impl Add<QuayLength> for QuayPosition {
-    type Output = QuayPosition;
+impl Add<SpaceLength> for SpacePosition {
+    type Output = SpacePosition;
 
-    /// Adds a `QuayLength` to a `QuayPosition`, returning a new `QuayPosition`.
+    /// Adds a `SpaceLength` to a `SpacePosition`, returning a new `SpacePosition`.
     ///
-    /// This method takes a `QuayLength` and adds it to the current `QuayPosition`,
-    /// returning a new `QuayPosition` with the updated value.
+    /// This method takes a `SpaceLength` and adds it to the current `SpacePosition`,
+    /// returning a new `SpacePosition` with the updated value.
     ///
     /// # Panics
     ///
@@ -1330,30 +1329,30 @@ impl Add<QuayLength> for QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let seg_idx = QuayPosition::new(5);
-    /// let length = QuayLength::new(3);
-    /// let new_seg_idx = seg_idx + length;
-    /// assert_eq!(new_seg_idx.value(), 8);
+    /// let pos = SpacePosition::new(5);
+    /// let length = SpaceLength::new(3);
+    /// let new_pos = pos + length;
+    /// assert_eq!(new_pos.value(), 8);
     /// ```
     #[inline]
-    fn add(self, rhs: QuayLength) -> Self::Output {
-        QuayPosition(
+    fn add(self, rhs: SpaceLength) -> Self::Output {
+        SpacePosition(
             self.0
                 .checked_add(rhs.0)
-                .expect("overflow in QuayPosition + QuayLength"),
+                .expect("overflow in SpacePosition + SpaceLength"),
         )
     }
 }
 
-impl Add<QuayPosition> for QuayLength {
-    type Output = QuayPosition;
+impl Add<SpacePosition> for SpaceLength {
+    type Output = SpacePosition;
 
-    /// Adds a `QuayPosition` to a `QuayLength`, returning a new `QuayPosition`.
+    /// Adds a `SpacePosition` to a `SpaceLength`, returning a new `SpacePosition`.
     ///
-    /// This method takes a `QuayPosition` and adds it to the current `QuayLength`,
-    /// returning a new `QuayPosition` with the updated value.
+    /// This method takes a `SpacePosition` and adds it to the current `SpaceLength`,
+    /// returning a new `SpacePosition` with the updated value.
     ///
     /// # Panics
     ///
@@ -1362,26 +1361,26 @@ impl Add<QuayPosition> for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let length = QuayLength::new(3);
-    /// let seg_idx = QuayPosition::new(5);
-    /// let new_seg_idx = length + seg_idx;
-    /// assert_eq!(new_seg_idx.value(), 8);
+    /// let length = SpaceLength::new(3);
+    /// let pos = SpacePosition::new(5);
+    /// let new_pos = length + pos;
+    /// assert_eq!(new_pos.value(), 8);
     /// ```
     #[inline]
-    fn add(self, rhs: QuayPosition) -> Self::Output {
+    fn add(self, rhs: SpacePosition) -> Self::Output {
         rhs + self
     }
 }
 
-impl Sub<QuayLength> for QuayPosition {
-    type Output = QuayPosition;
+impl Sub<SpaceLength> for SpacePosition {
+    type Output = SpacePosition;
 
-    /// Subtracts a `QuayLength` from a `QuayPosition`, returning a new `QuayPosition`.
+    /// Subtracts a `SpaceLength` from a `SpacePosition`, returning a new `SpacePosition`.
     ///
-    /// This method takes a `QuayLength` and subtracts it from the current `QuayPosition`,
-    /// returning a new `QuayPosition` with the updated value.
+    /// This method takes a `SpaceLength` and subtracts it from the current `SpacePosition`,
+    /// returning a new `SpacePosition` with the updated value.
     ///
     /// # Panics
     ///
@@ -1390,30 +1389,30 @@ impl Sub<QuayLength> for QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let seg_idx = QuayPosition::new(5);
-    /// let length = QuayLength::new(3);
-    /// let new_seg_idx = seg_idx - length;
-    /// assert_eq!(new_seg_idx.value(), 2);
+    /// let pos = SpacePosition::new(5);
+    /// let length = SpaceLength::new(3);
+    /// let new_pos = pos - length;
+    /// assert_eq!(new_pos.value(), 2);
     /// ```
     #[inline]
-    fn sub(self, rhs: QuayLength) -> Self::Output {
-        QuayPosition(
+    fn sub(self, rhs: SpaceLength) -> Self::Output {
+        SpacePosition(
             self.0
                 .checked_sub(rhs.0)
-                .expect("underflow in QuayPosition - QuayLength"),
+                .expect("underflow in SpacePosition - SpaceLength"),
         )
     }
 }
 
-impl Sub<QuayPosition> for QuayPosition {
-    type Output = QuayLength;
+impl Sub<SpacePosition> for SpacePosition {
+    type Output = SpaceLength;
 
-    /// Subtracts one `QuayPosition` from another, returning a `QuayLength`.
+    /// Subtracts one `SpacePosition` from another, returning a `SpaceLength`.
     ///
-    /// This method takes another `QuayPosition` and subtracts it from the current instance,
-    /// returning a new `QuayLength` that represents the difference between the two indices.
+    /// This method takes another `SpacePosition` and subtracts it from the current instance,
+    /// returning a new `SpaceLength` that represents the difference between the two indices.
     ///
     /// # Panics
     ///
@@ -1422,27 +1421,27 @@ impl Sub<QuayPosition> for QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let seg_idx1 = QuayPosition::new(10);
-    /// let seg_idx2 = QuayPosition::new(5);
-    /// let length = seg_idx1 - seg_idx2;
+    /// let pos1 = SpacePosition::new(10);
+    /// let pos2 = SpacePosition::new(5);
+    /// let length = pos1 - pos2;
     /// assert_eq!(length.value(), 5);
     /// ```
     #[inline]
-    fn sub(self, rhs: QuayPosition) -> Self::Output {
-        QuayLength(
+    fn sub(self, rhs: SpacePosition) -> Self::Output {
+        SpaceLength(
             self.0
                 .checked_sub(rhs.0)
-                .expect("underflow in QuayPosition - QuayPosition"),
+                .expect("underflow in SpacePosition - SpacePosition"),
         )
     }
 }
 
-impl AddAssign<QuayLength> for QuayPosition {
-    /// Adds a `QuayLength` to the current `QuayPosition`, modifying it in place.
+impl AddAssign<SpaceLength> for SpacePosition {
+    /// Adds a `SpaceLength` to the current `SpacePosition`, modifying it in place.
     ///
-    /// This method takes a `QuayLength` and adds it to the current `QuayPosition`,
+    /// This method takes a `SpaceLength` and adds it to the current `SpacePosition`,
     /// modifying the current instance to reflect the new value.
     ///
     /// # Panics
@@ -1452,26 +1451,26 @@ impl AddAssign<QuayLength> for QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let mut seg_idx = QuayPosition::new(5);
-    /// let length = QuayLength::new(3);
-    /// seg_idx += length;
-    /// assert_eq!(seg_idx.value(), 8);
+    /// let mut pos = SpacePosition::new(5);
+    /// let length = SpaceLength::new(3);
+    /// pos += length;
+    /// assert_eq!(pos.value(), 8);
     /// ```
     #[inline]
-    fn add_assign(&mut self, rhs: QuayLength) {
+    fn add_assign(&mut self, rhs: SpaceLength) {
         self.0 = self
             .0
             .checked_add(rhs.0)
-            .expect("overflow in QuayPosition += QuayLength");
+            .expect("overflow in SpacePosition += SpaceLength");
     }
 }
 
-impl SubAssign<QuayLength> for QuayPosition {
-    /// Subtracts a `QuayLength` from the current `QuayPosition`, modifying it in place.
+impl SubAssign<SpaceLength> for SpacePosition {
+    /// Subtracts a `SpaceLength` from the current `SpacePosition`, modifying it in place.
     ///
-    /// This method takes a `QuayLength` and subtracts it from the current `QuayPosition`,
+    /// This method takes a `SpaceLength` and subtracts it from the current `SpacePosition`,
     /// modifying the current instance to reflect the new value.
     ///
     /// # Panics
@@ -1481,110 +1480,110 @@ impl SubAssign<QuayLength> for QuayPosition {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::{QuayPosition, QuayLength};
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength};
     ///
-    /// let mut seg_idx = QuayPosition::new(5);
-    /// let length = QuayLength::new(3);
-    /// seg_idx -= length;
-    /// assert_eq!(seg_idx.value(), 2);
+    /// let mut pos = SpacePosition::new(5);
+    /// let length = SpaceLength::new(3);
+    /// pos -= length;
+    /// assert_eq!(pos.value(), 2);
     /// ```
     #[inline]
-    fn sub_assign(&mut self, rhs: QuayLength) {
+    fn sub_assign(&mut self, rhs: SpaceLength) {
         self.0 = self
             .0
             .checked_sub(rhs.0)
-            .expect("underflow in QuayPosition -= QuayLength");
+            .expect("underflow in SpacePosition -= SpaceLength");
     }
 }
 
-/// Represents the length of a segment along a quay.
+/// Represents a non-negative length along the space.
 ///
-/// A `QuayLength` is a wrapper around a primitive unsigned integer type
-/// that represents the length of a segment along the quay.
+/// A `SpaceLength` is a wrapper around a primitive unsigned integer type
+/// that represents a length or size along a quay or similar structure.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_core::domain::QuayLength;
+/// use dock_alloc_core::domain::SpaceLength;
 ///
-/// let seg_length = QuayLength::new(10);
+/// let seg_length = SpaceLength::new(10);
 /// assert_eq!(seg_length.value(), 10);
-/// assert_eq!(format!("{}", seg_length), "QuayLength(10)");
+/// assert_eq!(format!("{}", seg_length), "SpaceLength(10)");
 /// ```
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct QuayLength(usize);
+pub struct SpaceLength(usize);
 
-impl Display for QuayLength {
-    /// Formats the `QuayLength` as `QuayLength(value)`.
+impl Display for SpaceLength {
+    /// Formats the `SpaceLength` as `SpaceLength(value)`.
     ///
-    /// Formats the `QuayLength` instance as a string in the format `QuayLength(value)`,
-    /// where `value` is the inner value of the `QuayLength`.
+    /// Formats the `SpaceLength` instance as a string in the format `SpaceLength(value)`,
+    /// where `value` is the inner value of the `SpaceLength`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let seg_length = QuayLength::new(10);
-    /// assert_eq!(format!("{}", seg_length), "QuayLength(10)");
+    /// let seg_length = SpaceLength::new(10);
+    /// assert_eq!(format!("{}", seg_length), "SpaceLength(10)");
     /// ```
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "QuayLength({})", self.0)
+        write!(f, "SpaceLength({})", self.0)
     }
 }
 
-impl From<usize> for QuayLength {
-    /// Converts a primitive unsigned integer type into a `QuayLength`.
+impl From<usize> for SpaceLength {
+    /// Converts a primitive unsigned integer type into a `SpaceLength`.
     ///
     /// This implementation allows for easy conversion from a primitive unsigned integer type
-    /// to a `QuayLength`, enabling the use of `QuayLength`
+    /// to a `SpaceLength`, enabling the use of `SpaceLength`
     /// in contexts where a primitive unsigned integer is available.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
     /// let value: usize = 10;
-    /// let seg_length: QuayLength = QuayLength::from(value);
+    /// let seg_length: SpaceLength = SpaceLength::from(value);
     /// assert_eq!(seg_length.value(), 10);
     /// ```
     #[inline]
     fn from(v: usize) -> Self {
-        QuayLength(v)
+        SpaceLength(v)
     }
 }
 
-impl QuayLength {
-    /// Creates a new `QuayLength` with the given value.
+impl SpaceLength {
+    /// Creates a new `SpaceLength` with the given value.
     ///
-    /// Creates a new `QuayLength` instance wrapping the provided `usize` value.
+    /// Creates a new `SpaceLength` instance wrapping the provided `usize` value.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(10);
+    /// let len = SpaceLength::new(10);
     /// assert_eq!(len.value(), 10);
     /// ```
     #[inline(always)]
     pub const fn new(v: usize) -> Self {
-        QuayLength(v)
+        SpaceLength(v)
     }
 
-    /// Returns the inner value of the `QuayLength`.
+    /// Returns the inner value of the `SpaceLength`.
     ///
-    /// Extracts the primitive `usize` value from the `QuayLength` wrapper.
+    /// Extracts the primitive `usize` value from the `SpaceLength` wrapper.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(10);
+    /// let len = SpaceLength::new(10);
     /// assert_eq!(len.value(), 10);
     /// ```
     #[inline(always)]
@@ -1599,14 +1598,14 @@ impl QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(usize::MAX);
-    /// assert!(len.checked_add(QuayLength::new(1)).is_none());
+    /// let len = SpaceLength::new(usize::MAX);
+    /// assert!(len.checked_add(SpaceLength::new(1)).is_none());
     /// ```
     #[inline]
     pub fn checked_add(self, rhs: Self) -> Option<Self> {
-        self.0.checked_add(rhs.0).map(QuayLength)
+        self.0.checked_add(rhs.0).map(SpaceLength)
     }
 
     /// Computes `self - rhs`, returning `None` if underflow occurred.
@@ -1616,50 +1615,50 @@ impl QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(5);
-    /// assert!(len.checked_sub(QuayLength::new(10)).is_none());
+    /// let len = SpaceLength::new(5);
+    /// assert!(len.checked_sub(SpaceLength::new(10)).is_none());
     /// ```
     #[inline]
     pub fn checked_sub(self, rhs: Self) -> Option<Self> {
-        self.0.checked_sub(rhs.0).map(QuayLength)
+        self.0.checked_sub(rhs.0).map(SpaceLength)
     }
 
     /// Saturating addition. Computes `self + rhs`, saturating at the numeric bounds.
     ///
-    /// Performs an addition that returns `QuayLength(usize::MAX)` if the result would overflow.
+    /// Performs an addition that returns `SpaceLength(usize::MAX)` if the result would overflow.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(usize::MAX - 2);
-    /// let result = len.saturating_add(QuayLength::new(5));
+    /// let len = SpaceLength::new(usize::MAX - 2);
+    /// let result = len.saturating_add(SpaceLength::new(5));
     /// assert_eq!(result.value(), usize::MAX);
     /// ```
     #[inline]
     pub fn saturating_add(self, rhs: Self) -> Self {
-        QuayLength(self.0.saturating_add(rhs.0))
+        SpaceLength(self.0.saturating_add(rhs.0))
     }
 
     /// Saturating subtraction. Computes `self - rhs`, saturating at zero.
     ///
-    /// Performs a subtraction that returns `QuayLength(0)` if the result would be negative.
+    /// Performs a subtraction that returns `SpaceLength(0)` if the result would be negative.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(5);
-    /// let result = len.saturating_sub(QuayLength::new(10));
+    /// let len = SpaceLength::new(5);
+    /// let result = len.saturating_sub(SpaceLength::new(10));
     /// assert_eq!(result.value(), 0);
     /// ```
     #[inline]
     pub fn saturating_sub(self, rhs: Self) -> Self {
-        QuayLength(self.0.saturating_sub(rhs.0))
+        SpaceLength(self.0.saturating_sub(rhs.0))
     }
 
     /// Computes `self * rhs`, returning `None` if overflow occurred.
@@ -1669,14 +1668,14 @@ impl QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(usize::MAX);
+    /// let len = SpaceLength::new(usize::MAX);
     /// assert!(len.checked_mul(2).is_none());
     /// ```
     #[inline]
     pub fn checked_mul(self, rhs: usize) -> Option<Self> {
-        self.0.checked_mul(rhs).map(QuayLength)
+        self.0.checked_mul(rhs).map(SpaceLength)
     }
 
     /// Computes `self / rhs`, returning `None` if `rhs` is zero.
@@ -1686,26 +1685,26 @@ impl QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(10);
+    /// let len = SpaceLength::new(10);
     /// assert!(len.checked_div(0).is_none());
     /// ```
     #[inline]
     pub fn checked_div(self, rhs: usize) -> Option<Self> {
-        self.0.checked_div(rhs).map(QuayLength)
+        self.0.checked_div(rhs).map(SpaceLength)
     }
 
     /// Saturating multiplication. Computes `self * rhs`, saturating at the numeric bounds.
     ///
-    /// Performs a multiplication that returns `QuayLength(usize::MAX)` if the result would overflow.
+    /// Performs a multiplication that returns `SpaceLength(usize::MAX)` if the result would overflow.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(usize::MAX / 2);
+    /// let len = SpaceLength::new(usize::MAX / 2);
     /// let result = len.saturating_mul(3);
     /// assert_eq!(result.value(), usize::MAX);
     /// ```
@@ -1714,16 +1713,16 @@ impl QuayLength {
         Self(self.0.saturating_mul(rhs))
     }
 
-    /// Creates a new `QuayLength` with a value of zero.
+    /// Creates a new `SpaceLength` with a value of zero.
     ///
     /// This is useful for representing a zero-length segment.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::zero();
+    /// let len = SpaceLength::zero();
     /// assert!(len.is_zero());
     /// ```
     #[inline(always)]
@@ -1731,16 +1730,16 @@ impl QuayLength {
         Self(0)
     }
 
-    /// Returns the absolute value of the `QuayLength`.
+    /// Returns the absolute value of the `SpaceLength`.
     ///
-    /// Since `QuayLength` is always non-negative, this method simply returns a copy.
+    /// Since `SpaceLength` is always non-negative, this method simply returns a copy.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let len = QuayLength::new(10);
+    /// let len = SpaceLength::new(10);
     /// assert_eq!(len.abs(), len);
     /// ```
     #[inline(always)]
@@ -1748,34 +1747,34 @@ impl QuayLength {
         self
     }
 
-    /// Checks if the `QuayLength` is zero.
+    /// Checks if the `SpaceLength` is zero.
     ///
     /// Returns `true` if the length is zero.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// assert!(QuayLength::new(0).is_zero());
-    /// assert!(!QuayLength::new(1).is_zero());
+    /// assert!(SpaceLength::new(0).is_zero());
+    /// assert!(!SpaceLength::new(1).is_zero());
     /// ```
     #[inline(always)]
     pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
 
-    /// Checks if the `QuayLength` is positive.
+    /// Checks if the `SpaceLength` is positive.
     ///
     /// Returns `true` if the length is greater than zero.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// assert!(QuayLength::new(1).is_positive());
-    /// assert!(!QuayLength::new(0).is_positive());
+    /// assert!(SpaceLength::new(1).is_positive());
+    /// assert!(!SpaceLength::new(0).is_positive());
     /// ```
     #[inline(always)]
     pub const fn is_positive(self) -> bool {
@@ -1783,41 +1782,41 @@ impl QuayLength {
     }
 }
 
-impl Zero for QuayLength {
-    /// Returns a `QuayLength` with a value of zero.
+impl Zero for SpaceLength {
+    /// Returns a `SpaceLength` with a value of zero.
     ///
-    /// This implementation provides a `QuayLength` with a value of zero,
-    /// which is useful when you need to initialize a `QuayLength`
+    /// This implementation provides a `SpaceLength` with a value of zero,
+    /// which is useful when you need to initialize a `SpaceLength`
     /// without a specific value.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     /// use num_traits::Zero;
     ///
-    /// let seg_length: QuayLength = QuayLength::zero();
+    /// let seg_length: SpaceLength = SpaceLength::zero();
     /// assert!(seg_length.is_zero());
     /// ```
     #[inline]
     fn zero() -> Self {
-        QuayLength::new(0)
+        SpaceLength::new(0)
     }
 
-    /// Checks if the `QuayLength` is zero.
+    /// Checks if the `SpaceLength` is zero.
     ///
-    /// This implementation checks if the inner value of the `QuayLength` is zero,
-    /// which is useful for determining if a `QuayLength` represents no length.
+    /// This implementation checks if the inner value of the `SpaceLength` is zero,
+    /// which is useful for determining if a `SpaceLength` represents no length.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     /// use num_traits::identities::Zero;
     ///
-    /// let seg_length: QuayLength = QuayLength::zero();
+    /// let seg_length: SpaceLength = SpaceLength::zero();
     /// assert!(seg_length.is_zero());
-    /// let non_zero_seg_length: QuayLength = QuayLength::new(10);
+    /// let non_zero_seg_length: SpaceLength = SpaceLength::new(10);
     /// assert!(!non_zero_seg_length.is_zero());
     /// ```
     #[inline]
@@ -1826,13 +1825,13 @@ impl Zero for QuayLength {
     }
 }
 
-impl Add for QuayLength {
-    type Output = QuayLength;
+impl Add for SpaceLength {
+    type Output = SpaceLength;
 
-    /// Adds two `QuayLength`s, returning a new `QuayLength`.
+    /// Adds two `SpaceLength`s, returning a new `SpaceLength`.
     ///
-    /// This method takes another `QuayLength` and adds it to the current instance,
-    /// returning a new `QuayLength` with the updated value.
+    /// This method takes another `SpaceLength` and adds it to the current instance,
+    /// returning a new `SpaceLength` with the updated value.
     ///
     /// # Panics
     ///
@@ -1841,29 +1840,29 @@ impl Add for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let seg_length1 = QuayLength::new(10);
-    /// let seg_length2 = QuayLength::new(5);
+    /// let seg_length1 = SpaceLength::new(10);
+    /// let seg_length2 = SpaceLength::new(5);
     /// let result = seg_length1 + seg_length2;
     /// assert_eq!(result.value(), 15);
     /// ```
     #[inline]
     fn add(self, rhs: Self) -> Self::Output {
-        QuayLength(
+        SpaceLength(
             self.0
                 .checked_add(rhs.0)
-                .expect("overflow in QuayLength + QuayLength"),
+                .expect("overflow in SpaceLength + SpaceLength"),
         )
     }
 }
-impl Sub for QuayLength {
-    type Output = QuayLength;
+impl Sub for SpaceLength {
+    type Output = SpaceLength;
 
-    /// Subtracts one `QuayLength` from another, returning a new `QuayLength`.
+    /// Subtracts one `SpaceLength` from another, returning a new `SpaceLength`.
     ///
-    /// This method takes another `QuayLength` and subtracts it from the current instance,
-    /// returning a new `QuayLength` with the updated value.
+    /// This method takes another `SpaceLength` and subtracts it from the current instance,
+    /// returning a new `SpaceLength` with the updated value.
     ///
     /// # Panics
     ///
@@ -1872,26 +1871,26 @@ impl Sub for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let seg_length1 = QuayLength::new(10);
-    /// let seg_length2 = QuayLength::new(5);
+    /// let seg_length1 = SpaceLength::new(10);
+    /// let seg_length2 = SpaceLength::new(5);
     /// let result = seg_length1 - seg_length2;
     /// assert_eq!(result.value(), 5);
     /// ```
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
-        QuayLength(
+        SpaceLength(
             self.0
                 .checked_sub(rhs.0)
-                .expect("underflow in QuayLength - QuayLength"),
+                .expect("underflow in SpaceLength - SpaceLength"),
         )
     }
 }
-impl AddAssign for QuayLength {
-    /// Adds another `QuayLength` to the current instance, modifying it in place.
+impl AddAssign for SpaceLength {
+    /// Adds another `SpaceLength` to the current instance, modifying it in place.
     ///
-    /// This method takes another `QuayLength` and adds it to the current instance,
+    /// This method takes another `SpaceLength` and adds it to the current instance,
     /// modifying the current instance to reflect the new value.
     ///
     /// # Panics
@@ -1901,10 +1900,10 @@ impl AddAssign for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let mut seg_length1 = QuayLength::new(10);
-    /// let seg_length2 = QuayLength::new(5);
+    /// let mut seg_length1 = SpaceLength::new(10);
+    /// let seg_length2 = SpaceLength::new(5);
     /// seg_length1 += seg_length2;
     /// assert_eq!(seg_length1.value(), 15);
     /// ```
@@ -1913,14 +1912,14 @@ impl AddAssign for QuayLength {
         self.0 = self
             .0
             .checked_add(rhs.0)
-            .expect("overflow in QuayLength += QuayLength");
+            .expect("overflow in SpaceLength += SpaceLength");
     }
 }
 
-impl SubAssign for QuayLength {
-    /// Subtracts another `QuayLength` from the current instance, modifying it in place.
+impl SubAssign for SpaceLength {
+    /// Subtracts another `SpaceLength` from the current instance, modifying it in place.
     ///
-    /// This method takes another `QuayLength` and subtracts it from the current instance,
+    /// This method takes another `SpaceLength` and subtracts it from the current instance,
     /// modifying the current instance to reflect the new value.
     ///
     /// # Panics
@@ -1930,10 +1929,10 @@ impl SubAssign for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let mut seg_length1 = QuayLength::new(10);
-    /// let seg_length2 = QuayLength::new(5);
+    /// let mut seg_length1 = SpaceLength::new(10);
+    /// let seg_length2 = SpaceLength::new(5);
     /// seg_length1 -= seg_length2;
     /// assert_eq!(seg_length1.value(), 5);
     /// ```
@@ -1942,17 +1941,17 @@ impl SubAssign for QuayLength {
         self.0 = self
             .0
             .checked_sub(rhs.0)
-            .expect("underflow in QuayLength -= QuayLength");
+            .expect("underflow in SpaceLength -= SpaceLength");
     }
 }
 
-impl Mul<usize> for QuayLength {
-    type Output = QuayLength;
+impl Mul<usize> for SpaceLength {
+    type Output = SpaceLength;
 
-    /// Multiplies a `QuayLength` by a primitive unsigned integer type, returning a new `QuayLength`.
+    /// Multiplies a `SpaceLength` by a primitive unsigned integer type, returning a new `SpaceLength`.
     ///
-    /// This method takes a primitive unsigned integer type and multiplies it with the current `QuayLength`,
-    /// returning a new `QuayLength` with the updated value.
+    /// This method takes a primitive unsigned integer type and multiplies it with the current `SpaceLength`,
+    /// returning a new `SpaceLength` with the updated value.
     ///
     /// # Panics
     ///
@@ -1961,29 +1960,29 @@ impl Mul<usize> for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let seg_length1 = QuayLength::new(10);
+    /// let seg_length1 = SpaceLength::new(10);
     /// let result = seg_length1 * 2;
     /// assert_eq!(result.value(), 20);
     /// ```
     #[inline]
     fn mul(self, rhs: usize) -> Self::Output {
-        QuayLength(
+        SpaceLength(
             self.0
                 .checked_mul(rhs)
-                .expect("overflow in QuayLength * usize"),
+                .expect("overflow in SpaceLength * usize"),
         )
     }
 }
 
-impl Div<usize> for QuayLength {
-    type Output = QuayLength;
+impl Div<usize> for SpaceLength {
+    type Output = SpaceLength;
 
-    /// Divides one `QuayLength` by a usize, returning a new `QuayLength`.
+    /// Divides one `SpaceLength` by a usize, returning a new `SpaceLength`.
     ///
-    /// This method takes a usize and divides the current `QuayLength` by it,
-    /// returning a new `QuayLength` with the updated value.
+    /// This method takes a usize and divides the current `SpaceLength` by it,
+    /// returning a new `SpaceLength` with the updated value.
     ///
     /// # Panics
     ///
@@ -1992,35 +1991,35 @@ impl Div<usize> for QuayLength {
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let seg_length1 = QuayLength::new(10);
+    /// let seg_length1 = SpaceLength::new(10);
     /// let result = seg_length1 / 2;
     /// assert_eq!(result.value(), 5);
     /// ```
     #[inline]
     fn div(self, rhs: usize) -> Self::Output {
-        QuayLength(
+        SpaceLength(
             self.0
                 .checked_div(rhs)
-                .expect("division by zero in QuayLength / usize"),
+                .expect("division by zero in SpaceLength / usize"),
         )
     }
 }
 
-impl Sum for QuayLength {
-    /// Sums up a collection of `QuayLength` instances, returning a new `QuayLength`.
+impl Sum for SpaceLength {
+    /// Sums up a collection of `SpaceLength` instances, returning a new `SpaceLength`.
     ///
-    /// This method takes an iterator of `QuayLength` instances and sums them up,
-    /// returning a new `QuayLength` that represents the total length.
+    /// This method takes an iterator of `SpaceLength` instances and sums them up,
+    /// returning a new `SpaceLength` that represents the total length.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let lengths = vec![QuayLength::new(10), QuayLength::new(5)];
-    /// let total_length: QuayLength = lengths.into_iter().sum();
+    /// let lengths = vec![SpaceLength::new(10), SpaceLength::new(5)];
+    /// let total_length: SpaceLength = lengths.into_iter().sum();
     /// assert_eq!(total_length.value(), 15);
     /// ```
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -2028,19 +2027,19 @@ impl Sum for QuayLength {
     }
 }
 
-impl<'a> Sum<&'a QuayLength> for QuayLength {
-    /// Sums up a collection of references to `QuayLength` instances, returning a new `QuayLength`.
+impl<'a> Sum<&'a SpaceLength> for SpaceLength {
+    /// Sums up a collection of references to `SpaceLength` instances, returning a new `SpaceLength`.
     ///
-    /// This method takes an iterator of references to `QuayLength` instances and sums them up,
-    /// returning a new `QuayLength` that represents the total length.
+    /// This method takes an iterator of references to `SpaceLength` instances and sums them up,
+    /// returning a new `SpaceLength` that represents the total length.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_core::domain::QuayLength;
+    /// use dock_alloc_core::domain::SpaceLength;
     ///
-    /// let lengths = vec![QuayLength::new(10), QuayLength::new(5)];
-    /// let total_length: QuayLength = lengths.iter().sum();
+    /// let lengths = vec![SpaceLength::new(10), SpaceLength::new(5)];
+    /// let total_length: SpaceLength = lengths.iter().sum();
     /// assert_eq!(total_length.value(), 15);
     /// ```
     fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
@@ -2050,6 +2049,48 @@ impl<'a> Sum<&'a QuayLength> for QuayLength {
 
 pub type TimePoint64 = TimePoint<i64>;
 pub type TimeDelta64 = TimeDelta<i64>;
+
+impl<T: PrimInt + Signed> Interval<TimePoint<T>> {
+    /// Calculates the duration of the time interval.
+    ///
+    /// Returns a `TimeDelta` representing the difference between the end and start points of the interval.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_core::domain::{TimePoint, TimeDelta, TimeInterval};
+    ///
+    /// let start = TimePoint::new(10);
+    /// let end = TimePoint::new(20);
+    /// let interval = TimeInterval::new(start, end);
+    /// assert_eq!(interval.duration(), TimeDelta::new(10));
+    /// ```
+    #[inline]
+    pub fn duration(&self) -> TimeDelta<T> {
+        self.end() - self.start()
+    }
+}
+
+impl Interval<SpacePosition> {
+    /// Calculates the extent of the space interval.
+    ///
+    /// Returns a `SpaceLength` representing the difference between the end and start positions of the interval.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_core::domain::{SpacePosition, SpaceLength, SpaceInterval};
+    ///
+    /// let start = SpacePosition::new(10);
+    /// let end = SpacePosition::new(20);
+    /// let interval = SpaceInterval::new(start, end);
+    /// assert_eq!(interval.extent(), SpaceLength::new(10));
+    /// ```
+    #[inline]
+    pub fn extent(&self) -> SpaceLength {
+        self.end() - self.start()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -2325,198 +2366,195 @@ mod tests {
     }
 
     #[test]
-    fn test_quay_position_creation() {
-        let seg_idx = QuayPosition::new(5);
-        assert_eq!(seg_idx.value(), 5);
+    fn test_space_position_creation() {
+        let pos = SpacePosition::new(5);
+        assert_eq!(pos.value(), 5);
     }
 
     #[test]
-    fn test_quay_position_zero() {
-        let seg_idx = QuayPosition::zero();
-        assert_eq!(seg_idx.value(), 0);
-        assert!(seg_idx.is_zero());
+    fn test_space_position_zero() {
+        let pos = SpacePosition::zero();
+        assert_eq!(pos.value(), 0);
+        assert!(pos.is_zero());
     }
 
     #[test]
-    fn test_quay_position_display() {
-        let seg_idx = QuayPosition::new(5);
-        assert_eq!(format!("{}", seg_idx), "QuayPosition(5)");
+    fn test_space_position_display() {
+        let pos = SpacePosition::new(5);
+        assert_eq!(format!("{}", pos), "SpacePosition(5)");
     }
 
     #[test]
-    fn test_quay_position_from() {
+    fn test_space_position_from() {
         let value: usize = 5;
-        let seg_idx: QuayPosition = value.into();
-        assert_eq!(seg_idx.value(), 5);
+        let pos: SpacePosition = value.into();
+        assert_eq!(pos.value(), 5);
     }
 
     #[test]
-    fn test_quay_position_add_length() {
-        let seg_idx = QuayPosition::new(5);
-        let length = QuayLength::new(3);
-        assert_eq!((seg_idx + length).value(), 8);
+    fn test_space_position_add_length() {
+        let pos = SpacePosition::new(5);
+        let length = SpaceLength::new(3);
+        assert_eq!((pos + length).value(), 8);
     }
 
     #[test]
-    fn test_quay_position_add_assign_length() {
-        let mut seg_idx = QuayPosition::new(5);
-        seg_idx += QuayLength::new(3);
-        assert_eq!(seg_idx.value(), 8);
+    fn test_space_position_add_assign_length() {
+        let mut pos = SpacePosition::new(5);
+        pos += SpaceLength::new(3);
+        assert_eq!(pos.value(), 8);
     }
 
     #[test]
-    fn test_quay_position_sub_length() {
-        let seg_idx = QuayPosition::new(5);
-        let length = QuayLength::new(3);
-        assert_eq!((seg_idx - length).value(), 2);
+    fn test_space_position_sub_length() {
+        let pos = SpacePosition::new(5);
+        let length = SpaceLength::new(3);
+        assert_eq!((pos - length).value(), 2);
     }
 
     #[test]
-    fn test_quay_position_sub_assign_length() {
-        let mut seg_idx = QuayPosition::new(5);
-        seg_idx -= QuayLength::new(3);
-        assert_eq!(seg_idx.value(), 2);
+    fn test_space_position_sub_assign_length() {
+        let mut pos = SpacePosition::new(5);
+        pos -= SpaceLength::new(3);
+        assert_eq!(pos.value(), 2);
     }
 
     #[test]
-    fn test_quay_position_sub_index() {
-        let seg_idx1 = QuayPosition::new(10);
-        let seg_idx2 = QuayPosition::new(4);
-        let length = seg_idx1 - seg_idx2;
+    fn test_space_position_sub_index() {
+        let pos1 = SpacePosition::new(10);
+        let pos2 = SpacePosition::new(4);
+        let length = pos1 - pos2;
         assert_eq!(length.value(), 6);
-        assert_eq!(length, QuayLength::new(6));
+        assert_eq!(length, SpaceLength::new(6));
     }
 
     #[test]
-    fn test_quay_position_checked_add() {
-        let seg_idx = QuayPosition::new(usize::MAX - 1);
-        let length = QuayLength::new(1);
+    fn test_space_position_checked_add() {
+        let pos = SpacePosition::new(usize::MAX - 1);
+        let length = SpaceLength::new(1);
         assert_eq!(
-            seg_idx.checked_add(length),
-            Some(QuayPosition::new(usize::MAX))
+            pos.checked_add(length),
+            Some(SpacePosition::new(usize::MAX))
         );
-        let length_overflow = QuayLength::new(2);
-        assert_eq!(seg_idx.checked_add(length_overflow), None);
+        let length_overflow = SpaceLength::new(2);
+        assert_eq!(pos.checked_add(length_overflow), None);
     }
 
     #[test]
-    fn test_quay_position_checked_sub_len() {
-        let seg_idx = QuayPosition::new(1);
-        let length = QuayLength::new(1);
-        assert_eq!(seg_idx.checked_sub(length), Some(QuayPosition::new(0)));
-        let length_underflow = QuayLength::new(2);
-        assert_eq!(seg_idx.checked_sub(length_underflow), None);
+    fn test_space_position_checked_sub_len() {
+        let pos = SpacePosition::new(1);
+        let length = SpaceLength::new(1);
+        assert_eq!(pos.checked_sub(length), Some(SpacePosition::new(0)));
+        let length_underflow = SpaceLength::new(2);
+        assert_eq!(pos.checked_sub(length_underflow), None);
     }
 
     #[test]
-    fn test_quay_position_saturating_add() {
-        let seg_idx = QuayPosition::new(usize::MAX - 1);
-        let length = QuayLength::new(5);
-        assert_eq!(
-            seg_idx.saturating_add(length),
-            QuayPosition::new(usize::MAX)
-        );
+    fn test_space_position_saturating_add() {
+        let pos = SpacePosition::new(usize::MAX - 1);
+        let length = SpaceLength::new(5);
+        assert_eq!(pos.saturating_add(length), SpacePosition::new(usize::MAX));
     }
 
     #[test]
-    fn test_quay_position_saturating_sub() {
-        let seg_idx = QuayPosition::new(5);
-        let length = QuayLength::new(10);
-        assert_eq!(seg_idx.saturating_sub(length), QuayPosition::new(0));
+    fn test_space_position_saturating_sub() {
+        let pos = SpacePosition::new(5);
+        let length = SpaceLength::new(10);
+        assert_eq!(pos.saturating_sub(length), SpacePosition::new(0));
     }
 
     #[test]
-    fn test_quay_position_span_of() {
-        let seg_idx = QuayPosition::new(5);
-        let length = QuayLength::new(10);
-        let interval = seg_idx.span_of(length);
-        assert_eq!(interval.unwrap().start(), QuayPosition::new(5));
-        assert_eq!(interval.unwrap().end(), QuayPosition::new(15));
+    fn test_space_position_span_of() {
+        let pos = SpacePosition::new(5);
+        let length = SpaceLength::new(10);
+        let interval = pos.span_of(length);
+        assert_eq!(interval.unwrap().start(), SpacePosition::new(5));
+        assert_eq!(interval.unwrap().end(), SpacePosition::new(15));
     }
 
     #[test]
-    #[should_panic(expected = "overflow in QuayPosition + QuayLength")]
-    fn test_quay_position_add_panic_on_overflow() {
-        let seg_idx = QuayPosition::new(usize::MAX);
-        let length = QuayLength::new(1);
-        let _ = seg_idx + length;
+    #[should_panic(expected = "overflow in SpacePosition + SpaceLength")]
+    fn test_space_position_add_panic_on_overflow() {
+        let pos = SpacePosition::new(usize::MAX);
+        let length = SpaceLength::new(1);
+        let _ = pos + length;
     }
 
     #[test]
-    #[should_panic(expected = "underflow in QuayPosition - QuayLength")]
-    fn test_quay_position_sub_panic_on_underflow() {
-        let seg_idx = QuayPosition::new(0);
-        let length = QuayLength::new(1);
-        let _ = seg_idx - length;
+    #[should_panic(expected = "underflow in SpacePosition - SpaceLength")]
+    fn test_space_position_sub_panic_on_underflow() {
+        let pos = SpacePosition::new(0);
+        let length = SpaceLength::new(1);
+        let _ = pos - length;
     }
 
     #[test]
-    fn test_quay_length_creation() {
-        let seg_len = QuayLength::new(10);
+    fn test_space_length_creation() {
+        let seg_len = SpaceLength::new(10);
         assert_eq!(seg_len.value(), 10);
     }
 
     #[test]
-    fn test_quay_length_zero() {
-        let seg_len: QuayLength = num_traits::Zero::zero();
+    fn test_space_length_zero() {
+        let seg_len: SpaceLength = num_traits::Zero::zero();
         assert_eq!(seg_len.value(), 0);
         assert!(seg_len.is_zero());
     }
 
     #[test]
-    fn test_quay_length_display() {
-        let seg_len = QuayLength::new(10);
-        assert_eq!(format!("{}", seg_len), "QuayLength(10)");
+    fn test_space_length_display() {
+        let seg_len = SpaceLength::new(10);
+        assert_eq!(format!("{}", seg_len), "SpaceLength(10)");
     }
 
     #[test]
-    fn test_quay_length_from() {
+    fn test_space_length_from() {
         let value: usize = 10;
-        let seg_len: QuayLength = value.into();
+        let seg_len: SpaceLength = value.into();
         assert_eq!(seg_len.value(), 10);
     }
 
     #[test]
-    fn test_quay_length_add_length() {
-        let len1 = QuayLength::new(10);
-        let len2 = QuayLength::new(5);
+    fn test_space_length_add_length() {
+        let len1 = SpaceLength::new(10);
+        let len2 = SpaceLength::new(5);
         assert_eq!((len1 + len2).value(), 15);
     }
 
     #[test]
-    fn test_quay_length_add_assign_length() {
-        let mut len1 = QuayLength::new(10);
-        len1 += QuayLength::new(5);
+    fn test_space_length_add_assign_length() {
+        let mut len1 = SpaceLength::new(10);
+        len1 += SpaceLength::new(5);
         assert_eq!(len1.value(), 15);
     }
 
     #[test]
-    fn test_quay_length_sub_length() {
-        let len1 = QuayLength::new(10);
-        let len2 = QuayLength::new(5);
+    fn test_space_length_sub_length() {
+        let len1 = SpaceLength::new(10);
+        let len2 = SpaceLength::new(5);
         assert_eq!((len1 - len2).value(), 5);
     }
 
     #[test]
-    fn test_quay_length_sub_assign_length() {
-        let mut len1 = QuayLength::new(10);
-        len1 -= QuayLength::new(5);
+    fn test_space_length_sub_assign_length() {
+        let mut len1 = SpaceLength::new(10);
+        len1 -= SpaceLength::new(5);
         assert_eq!(len1.value(), 5);
     }
 
     #[test]
-    #[should_panic(expected = "overflow in QuayLength + QuayLength")]
-    fn test_quay_length_add_panic_on_overflow() {
-        let len1 = QuayLength::new(usize::MAX);
-        let len2 = QuayLength::new(1);
+    #[should_panic(expected = "overflow in SpaceLength + SpaceLength")]
+    fn test_space_length_add_panic_on_overflow() {
+        let len1 = SpaceLength::new(usize::MAX);
+        let len2 = SpaceLength::new(1);
         let _ = len1 + len2;
     }
 
     #[test]
-    #[should_panic(expected = "underflow in QuayLength - QuayLength")]
-    fn test_quay_length_sub_panic_on_underflow() {
-        let len1 = QuayLength::new(0);
-        let len2 = QuayLength::new(1);
+    #[should_panic(expected = "underflow in SpaceLength - SpaceLength")]
+    fn test_space_length_sub_panic_on_underflow() {
+        let len1 = SpaceLength::new(0);
+        let len2 = SpaceLength::new(1);
         let _ = len1 - len2;
     }
 
@@ -2553,22 +2591,22 @@ mod tests {
     }
 
     #[test]
-    fn test_quay_length_mul_scalar() {
-        let length = QuayLength::new(15);
-        assert_eq!(length * 2, QuayLength::new(30));
-        assert_eq!(length * 0, QuayLength::new(0));
+    fn test_space_length_mul_scalar() {
+        let length = SpaceLength::new(15);
+        assert_eq!(length * 2, SpaceLength::new(30));
+        assert_eq!(length * 0, SpaceLength::new(0));
     }
 
     #[test]
-    fn test_quay_length_div_scalar() {
-        let length = QuayLength::new(30);
-        assert_eq!(length / 3, QuayLength::new(10));
+    fn test_space_length_div_scalar() {
+        let length = SpaceLength::new(30);
+        assert_eq!(length / 3, SpaceLength::new(10));
     }
 
     #[test]
     #[should_panic(expected = "division by zero")]
-    fn test_quay_length_div_by_zero_panic() {
-        let length = QuayLength::new(30);
+    fn test_space_length_div_by_zero_panic() {
+        let length = SpaceLength::new(30);
         let _ = length / 0;
     }
 
@@ -2593,15 +2631,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "overflow in QuayLength * usize")]
-    fn test_quay_length_mul_panic_on_overflow() {
-        let length = QuayLength::new(usize::MAX);
+    #[should_panic(expected = "overflow in SpaceLength * usize")]
+    fn test_space_length_mul_panic_on_overflow() {
+        let length = SpaceLength::new(usize::MAX);
         let _ = length * 2;
     }
 
     #[test]
-    fn test_quay_length_div_truncation() {
-        let length = QuayLength::new(17);
-        assert_eq!(length / 4, QuayLength::new(4));
+    fn test_space_length_div_truncation() {
+        let length = SpaceLength::new(17);
+        assert_eq!(length / 4, SpaceLength::new(4));
     }
 }

--- a/crates/dock-alloc-core/src/domain.rs
+++ b/crates/dock-alloc-core/src/domain.rs
@@ -3654,21 +3654,21 @@ mod tests {
     }
 
     #[test]
-    fn cost_saturating_sub_unsigned_clamps_to_zero() {
+    fn test_cost_saturating_sub_unsigned_clamps_to_zero() {
         let a = Cost::new(10_u32);
         let b = Cost::new(20_u32);
         assert_eq!(a.saturating_sub(b).value(), 0);
     }
 
     #[test]
-    fn cost_saturating_sub_signed_clamps_to_min() {
+    fn test_cost_saturating_sub_signed_clamps_to_min() {
         let a = Cost::new(i32::MIN + 1);
         let b = Cost::new(5_i32);
         assert_eq!(a.saturating_sub(b).value(), i32::MIN);
     }
 
     #[test]
-    fn timedelta_division_truncates_toward_zero() {
+    fn test_timedelta_division_truncates_toward_zero() {
         assert_eq!(TimeDelta::new(10_i32) / -3, TimeDelta::new(-3));
         assert_eq!(TimeDelta::new(-10_i32) / 3, TimeDelta::new(-3));
     }

--- a/crates/dock-alloc-core/src/domain.rs
+++ b/crates/dock-alloc-core/src/domain.rs
@@ -77,7 +77,7 @@ use std::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TimePoint<T: PrimInt>(T);
 
-impl<T: PrimInt + Signed + Display> Display for TimePoint<T> {
+impl<T: PrimInt + Display> Display for TimePoint<T> {
     /// Formats the `TimePoint` as `TimePoint(value)`.
     ///
     /// # Examples
@@ -169,7 +169,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// let delta = TimeDelta::new(42);
     /// assert_eq!(delta.value(), 42);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn new(value: T) -> Self {
         Self(value)
     }
@@ -186,7 +186,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// let delta: TimeDelta<i32> = TimeDelta::zero();
     /// assert!(delta.is_zero());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn zero() -> Self {
         Self(T::zero())
     }
@@ -203,7 +203,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// let delta = TimeDelta::new(42);
     /// assert_eq!(delta.value(), 42);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn value(self) -> T {
         self.0
     }
@@ -220,7 +220,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// let delta = TimeDelta::new(-42);
     /// assert_eq!(delta.abs().value(), 42);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(self.0.abs())
     }
@@ -237,7 +237,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// assert!(TimeDelta::new(-1).is_negative());
     /// assert!(!TimeDelta::new(0).is_negative());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn is_negative(self) -> bool {
         self.0.is_negative()
     }
@@ -254,7 +254,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// assert!(TimeDelta::new(1).is_positive());
     /// assert!(!TimeDelta::new(0).is_positive());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn is_positive(self) -> bool {
         self.0.is_positive()
     }
@@ -271,7 +271,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     /// assert!(TimeDelta::new(0).is_zero());
     /// assert!(!TimeDelta::new(1).is_zero());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn is_zero(self) -> bool {
         self.0.is_zero()
     }
@@ -408,7 +408,7 @@ impl<T: PrimInt + Signed> TimeDelta<T> {
     }
 }
 
-impl<T: PrimInt + Signed> TimePoint<T> {
+impl<T: PrimInt> TimePoint<T> {
     /// Creates a new `TimePoint` with the given value.
     ///
     /// Creates a new `TimePoint` instance wrapping the provided value.
@@ -421,7 +421,7 @@ impl<T: PrimInt + Signed> TimePoint<T> {
     /// let tp = TimePoint::new(42_i32);
     /// assert_eq!(tp.value(), 42);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn new(value: T) -> Self {
         TimePoint(value)
     }
@@ -438,11 +438,13 @@ impl<T: PrimInt + Signed> TimePoint<T> {
     /// let tp = TimePoint::new(42_i32);
     /// assert_eq!(tp.value(), 42);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn value(self) -> T {
         self.0
     }
+}
 
+impl<T: PrimInt + Signed> TimePoint<T> {
     /// Computes `self + delta`, returning `None` if overflow occurred.
     ///
     /// Performs an addition that returns `None` instead of panicking if the result overflows.
@@ -1002,7 +1004,7 @@ impl<T: PrimInt + Signed> Mul<T> for TimeDelta<T> {
         TimeDelta::new(
             self.0
                 .checked_mul(&rhs)
-                .expect("overflow in TimeDelta * primitive integer"),
+                .expect("overflow in TimeDelta * scalar"),
         )
     }
 }
@@ -1030,7 +1032,7 @@ impl<T: PrimInt + Signed> MulAssign<T> for TimeDelta<T> {
         self.0 = self
             .0
             .checked_mul(&rhs)
-            .expect("overflow in TimeDelta *= primitive integer");
+            .expect("overflow in TimeDelta *= scalar");
     }
 }
 
@@ -1041,6 +1043,10 @@ impl<T: PrimInt + Signed> Div<T> for TimeDelta<T> {
     ///
     /// This method takes a primitive integer and divides the current `TimeDelta` by it,
     /// returning a new `TimeDelta` with the updated value.
+    ///
+    /// # Note
+    /// For signed `T`, division truncates toward zero (Rust semantics):
+    /// `10 / -3 == -3`, not `-4`. Panics on division by zero or `MIN / -1`.
     ///
     /// # Panics
     ///
@@ -1059,7 +1065,7 @@ impl<T: PrimInt + Signed> Div<T> for TimeDelta<T> {
         TimeDelta::new(
             self.0
                 .checked_div(&rhs)
-                .expect("overflow or division by zero in TimeDelta / primitive integer"),
+                .expect("div-by-zero or overflow in TimeDelta / scalar"),
         )
     }
 }
@@ -1087,7 +1093,7 @@ impl<T: PrimInt + Signed> DivAssign<T> for TimeDelta<T> {
         self.0 = self
             .0
             .checked_div(&rhs)
-            .expect("overflow or division by zero in TimeDelta /= primitive integer");
+            .expect("div-by-zero or overflow in TimeDelta /= scalar");
     }
 }
 
@@ -1311,7 +1317,7 @@ impl SpacePosition {
     /// let pos = SpacePosition::new(5);
     /// assert_eq!(pos.value(), 5);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn new(v: usize) -> Self {
         SpacePosition(v)
     }
@@ -1328,7 +1334,7 @@ impl SpacePosition {
     /// let pos = SpacePosition::zero();
     /// assert_eq!(pos.value(), 0);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn zero() -> Self {
         SpacePosition(0)
     }
@@ -1345,7 +1351,7 @@ impl SpacePosition {
     /// let pos = SpacePosition::new(5);
     /// assert_eq!(pos.value(), 5);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn value(self) -> usize {
         self.0
     }
@@ -1362,7 +1368,7 @@ impl SpacePosition {
     /// assert!(SpacePosition::zero().is_zero());
     /// assert!(!SpacePosition::new(1).is_zero());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
@@ -1715,7 +1721,7 @@ impl SpaceLength {
     /// let len = SpaceLength::new(10);
     /// assert_eq!(len.value(), 10);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn new(v: usize) -> Self {
         SpaceLength(v)
     }
@@ -1732,7 +1738,7 @@ impl SpaceLength {
     /// let len = SpaceLength::new(10);
     /// assert_eq!(len.value(), 10);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn value(self) -> usize {
         self.0
     }
@@ -1871,7 +1877,7 @@ impl SpaceLength {
     /// let len = SpaceLength::zero();
     /// assert!(len.is_zero());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn zero() -> Self {
         Self(0)
     }
@@ -1888,7 +1894,7 @@ impl SpaceLength {
     /// let len = SpaceLength::new(10);
     /// assert_eq!(len.abs(), len);
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn abs(self) -> Self {
         self
     }
@@ -1905,7 +1911,7 @@ impl SpaceLength {
     /// assert!(SpaceLength::new(0).is_zero());
     /// assert!(!SpaceLength::new(1).is_zero());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
@@ -1922,7 +1928,7 @@ impl SpaceLength {
     /// assert!(SpaceLength::new(1).is_positive());
     /// assert!(!SpaceLength::new(0).is_positive());
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn is_positive(self) -> bool {
         self.0 != 0
     }
@@ -2211,7 +2217,7 @@ impl Mul<usize> for SpaceLength {
         SpaceLength(
             self.0
                 .checked_mul(rhs)
-                .expect("overflow in SpaceLength * usize"),
+                .expect("overflow in SpaceLength * scalar"),
         )
     }
 }
@@ -2240,7 +2246,7 @@ impl MulAssign<usize> for SpaceLength {
         self.0 = self
             .0
             .checked_mul(rhs)
-            .expect("overflow in SpaceLength *= usize");
+            .expect("overflow in SpaceLength *= scalar");
     }
 }
 
@@ -2251,6 +2257,10 @@ impl Div<usize> for SpaceLength {
     ///
     /// This method takes a usize and divides the current `SpaceLength` by it,
     /// returning a new `SpaceLength` with the updated value.
+    ///
+    /// # Note
+    ///
+    /// Unsigned integer division; panics on division by zero.
     ///
     /// # Panics
     ///
@@ -2270,7 +2280,7 @@ impl Div<usize> for SpaceLength {
         SpaceLength(
             self.0
                 .checked_div(rhs)
-                .expect("division by zero in SpaceLength / usize"),
+                .expect("division by zero in SpaceLength / scalar"),
         )
     }
 }
@@ -2299,7 +2309,7 @@ impl DivAssign<usize> for SpaceLength {
         self.0 = self
             .0
             .checked_div(rhs)
-            .expect("division by zero in SpaceLength /= usize");
+            .expect("division by zero in SpaceLength /= scalar");
     }
 }
 
@@ -2487,19 +2497,25 @@ impl<T: Copy> Cost<T> {
         Cost(self.0.saturating_add(&other.0))
     }
 
-    /// Saturating subtraction. Computes `self - other`, saturatring at bounds.
+    /// Saturating subtraction. Computes `self - other`, saturating at numeric bounds.
     ///
-    /// Performs a subtraction that returns `Cost(0)` if the result would overflow.
+    /// Behavior depends on `T`:
+    /// - Unsigned (e.g., `u32`): clamps at `0`.
+    /// - Signed (e.g., `i32`): clamps at `T::MIN`.
     ///
     /// # Examples
-    ///
     /// ```
     /// use dock_alloc_core::domain::Cost;
     ///
-    /// let cost1 = Cost::new(5);
-    /// let cost2 = Cost::new(10);
-    /// let result = cost1.saturating_sub(cost2);
-    /// assert_eq!(result.value(), -5);
+    /// // Unsigned: clamps to 0
+    /// let a = Cost::new(10_u32);
+    /// let b = Cost::new(20_u32);
+    /// assert_eq!(a.saturating_sub(b).value(), 0);
+    ///
+    /// // Signed: clamps to i32::MIN
+    /// let c = Cost::new(i32::MIN + 1);
+    /// let d = Cost::new(5_i32);
+    /// assert_eq!(c.saturating_sub(d).value(), i32::MIN);
     /// ```
     #[inline]
     pub fn saturating_sub(self, other: Cost<T>) -> Self
@@ -2743,15 +2759,19 @@ where
     /// This method takes another `Cost` and subtracts it from the current instance,
     /// returning a new `Cost` that saturates at zero if the subtraction would result in a negative value.
     ///
+    /// Behavior depends on `T`:
+    /// - Unsigned (e.g., `u32`): clamps at `0`.
+    /// - Signed (e.g., `i32`): clamps at `T::MIN`.
+    ///
     /// # Examples
     ///
     /// ```
     /// use dock_alloc_core::domain::Cost;
     ///
-    /// let cost1 = Cost::new(5);
+    /// let cost1 = Cost::new(15);
     /// let cost2 = Cost::new(10);
     /// let result = cost1.saturating_sub(cost2);
-    /// assert_eq!(result.value(), -5);
+    /// assert_eq!(result.value(), 5);
     /// ```
     #[inline]
     fn saturating_sub(&self, rhs: &Self) -> Self {
@@ -2785,7 +2805,7 @@ where
     /// ```
     #[inline]
     fn mul(self, rhs: T) -> Self::Output {
-        Cost(self.0.checked_mul(&rhs).expect("overflow in Cost * T"))
+        Cost(self.0.checked_mul(&rhs).expect("overflow in Cost * scalar"))
     }
 }
 
@@ -2813,7 +2833,10 @@ where
     /// ```
     #[inline]
     fn mul_assign(&mut self, rhs: T) {
-        self.0 = self.0.checked_mul(&rhs).expect("overflow in Cost *= T");
+        self.0 = self
+            .0
+            .checked_mul(&rhs)
+            .expect("overflow in Cost *= scalar");
     }
 }
 
@@ -2827,6 +2850,10 @@ where
     ///
     /// This method takes a primitive value and divides the current `Cost` by it,
     /// returning a new `Cost` with the updated value.
+    ///
+    /// # Note
+    /// For signed `T`, division truncates toward zero. Panics on division by zero.
+    /// For unsigned `T`, standard integer division.
     ///
     /// # Panics
     ///
@@ -2846,7 +2873,7 @@ where
         Cost(
             self.0
                 .checked_div(&rhs)
-                .expect("division by zero in Cost / T"),
+                .expect("division by zero in Cost / scalar"),
         )
     }
 }
@@ -2878,7 +2905,7 @@ where
         self.0 = self
             .0
             .checked_div(&rhs)
-            .expect("division by zero in Cost /= T");
+            .expect("division by zero in Cost /= scalar");
     }
 }
 
@@ -3460,7 +3487,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "overflow or division by zero in TimeDelta / primitive integer")]
+    #[should_panic(expected = "div-by-zero or overflow in TimeDelta / scalar")]
     fn test_timedelta_div_by_zero_panic() {
         let delta = TimeDelta::new(20_i32);
         let _ = delta / 0;
@@ -3487,14 +3514,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "overflow in TimeDelta * primitive integer")]
+    #[should_panic(expected = "overflow in TimeDelta * scalar")]
     fn test_timedelta_mul_panic_on_overflow() {
         let delta = TimeDelta::new(i32::MAX);
         let _ = delta * 2;
     }
 
     #[test]
-    #[should_panic(expected = "overflow or division by zero")]
+    #[should_panic(expected = "div-by-zero or overflow in TimeDelta / scalar")]
     fn test_timedelta_div_panic_on_overflow() {
         let delta = TimeDelta::new(i32::MIN);
         let _ = delta / -1;
@@ -3507,7 +3534,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "overflow in SpaceLength * usize")]
+    #[should_panic(expected = "overflow in SpaceLength * scalar")]
     fn test_space_length_mul_panic_on_overflow() {
         let length = SpaceLength::new(usize::MAX);
         let _ = length * 2;
@@ -3623,5 +3650,25 @@ mod tests {
         let cost3 = Cost::new(10_u32);
         let cost4 = Cost::new(20);
         assert_eq!(cost3.saturating_sub(cost4).value(), 0);
+    }
+
+    #[test]
+    fn cost_saturating_sub_unsigned_clamps_to_zero() {
+        let a = Cost::new(10_u32);
+        let b = Cost::new(20_u32);
+        assert_eq!(a.saturating_sub(b).value(), 0);
+    }
+
+    #[test]
+    fn cost_saturating_sub_signed_clamps_to_min() {
+        let a = Cost::new(i32::MIN + 1);
+        let b = Cost::new(5_i32);
+        assert_eq!(a.saturating_sub(b).value(), i32::MIN);
+    }
+
+    #[test]
+    fn timedelta_division_truncates_toward_zero() {
+        assert_eq!(TimeDelta::new(10_i32) / -3, TimeDelta::new(-3));
+        assert_eq!(TimeDelta::new(-10_i32) / 3, TimeDelta::new(-3));
     }
 }

--- a/crates/dock-alloc-core/src/lib.rs
+++ b/crates/dock-alloc-core/src/lib.rs
@@ -19,5 +19,22 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+//! # Berth Allocation Core Library
+//!
+//! `dock_alloc_core` provides the foundational data structures and primitives
+//! for solving the Berth Allocation Problem (BAP). It offers a type-safe and
+//! robust API for representing the core concepts of time and quay space.
+//!
+//! This crate is the bedrock of the Dock Allocation project, designed to prevent
+//! common logical errors at compile time by using strong types for domain-specific
+//! concepts.
+//!
+//! ## Core Modules
+//!
+//! - **`domain`**: Contains the primary data types specific to BAP, such as
+//!   `TimePoint`, `TimeDelta`, `QuayPosition`, and `QuayLength`.
+//! - **`primitives`**: Provides generic, reusable structures like `Interval`, which
+//!   are used to build the more complex domain types.
+
 pub mod domain;
 pub mod primitives;

--- a/crates/dock-alloc-core/src/lib.rs
+++ b/crates/dock-alloc-core/src/lib.rs
@@ -32,7 +32,7 @@
 //! ## Core Modules
 //!
 //! - **`domain`**: Contains the primary data types specific to BAP, such as
-//!   `TimePoint`, `TimeDelta`, `QuayPosition`, and `QuayLength`.
+//!   `TimePoint`, `TimeDelta`, `SpacePosition`, and `SpaceLength`.
 //! - **`primitives`**: Provides generic, reusable structures like `Interval`, which
 //!   are used to build the more complex domain types.
 

--- a/crates/dock-alloc-core/src/lib.rs
+++ b/crates/dock-alloc-core/src/lib.rs
@@ -32,7 +32,7 @@
 //! ## Core Modules
 //!
 //! - **`domain`**: Contains the primary data types specific to BAP, such as
-//!   `TimePoint`, `TimeDelta`, `SpacePosition`, and `SpaceLength`.
+//!   `TimePoint`, `TimeDelta`, `SpacePosition`, `SpaceLength` and `Cost`.
 //! - **`primitives`**: Provides generic, reusable structures like `Interval`, which
 //!   are used to build the more complex domain types.
 

--- a/crates/dock-alloc-core/src/primitives.rs
+++ b/crates/dock-alloc-core/src/primitives.rs
@@ -638,14 +638,14 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn new_normalizes_order_integers() {
+    fn test_new_normalizes_order_integers() {
         let i = Interval::new(5i32, 3i32);
         assert_eq!(i.start(), 3);
         assert_eq!(i.end(), 5);
     }
 
     #[test]
-    fn new_keeps_order_when_sorted() {
+    fn test_new_keeps_order_when_sorted() {
         let i = Interval::new(-4i64, 9i64);
         assert_eq!(i.start(), -4);
         assert_eq!(i.end(), 9);
@@ -653,30 +653,30 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn new_panics_on_nan_left() {
+    fn test_new_panics_on_nan_left() {
         let _ = Interval::new(f64::NAN, 1.0f64);
     }
 
     #[test]
     #[should_panic]
-    fn new_panics_on_nan_right() {
+    fn test_new_panics_on_nan_right() {
         let _ = Interval::new(1.0f64, f64::NAN);
     }
 
     #[test]
-    fn is_empty_true_when_bounds_equal() {
+    fn test_is_empty_true_when_bounds_equal() {
         let i = Interval::new(5u32, 5u32);
         assert!(i.is_empty());
     }
 
     #[test]
-    fn is_empty_false_when_bounds_different() {
+    fn test_is_empty_false_when_bounds_different() {
         let i = Interval::new(1u32, 2u32);
         assert!(!i.is_empty());
     }
 
     #[test]
-    fn contains_inclusive_start_and_exclusive_end() {
+    fn test_contains_inclusive_start_and_exclusive_end() {
         let i = Interval::new(10i32, 20i32);
         assert!(i.contains(10));
         assert!(i.contains(19));
@@ -685,7 +685,7 @@ mod tests {
     }
 
     #[test]
-    fn contains_on_empty_interval_is_always_false() {
+    fn test_contains_on_empty_interval_is_always_false() {
         let i = Interval::new(3i32, 3i32);
         assert!(!i.contains(3));
         assert!(!i.contains(2));
@@ -693,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn contains_interval_true_for_nested_and_equal() {
+    fn test_contains_interval_true_for_nested_and_equal() {
         let a = Interval::new(1i32, 5i32);
         let b = Interval::new(2i32, 4i32);
         let c = Interval::new(1i32, 5i32);
@@ -702,21 +702,21 @@ mod tests {
     }
 
     #[test]
-    fn contains_interval_false_when_other_extends_outside() {
+    fn test_contains_interval_false_when_other_extends_outside() {
         let a = Interval::new(1i32, 5i32);
         let bigger = Interval::new(0i32, 6i32);
         assert!(!a.contains_interval(&bigger));
     }
 
     #[test]
-    fn contains_interval_true_for_empty_other_if_anchor_inside() {
+    fn test_contains_interval_true_for_empty_other_if_anchor_inside() {
         let a = Interval::new(1i32, 5i32);
         let empty_inside = Interval::new(3i32, 3i32);
         assert!(a.contains_interval(&empty_inside));
     }
 
     #[test]
-    fn intersects_true_on_overlap() {
+    fn test_intersects_true_on_overlap() {
         let a = Interval::new(0i32, 10i32);
         let b = Interval::new(5i32, 15i32);
         assert!(a.intersects(&b));
@@ -724,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn intersects_false_when_touching_at_endpoint() {
+    fn test_intersects_false_when_touching_at_endpoint() {
         let a = Interval::new(0i32, 10i32);
         let b = Interval::new(10i32, 20i32);
         assert!(!a.intersects(&b));
@@ -732,14 +732,14 @@ mod tests {
     }
 
     #[test]
-    fn intersects_false_when_disjoint() {
+    fn test_intersects_false_when_disjoint() {
         let a = Interval::new(0i32, 5i32);
         let b = Interval::new(6i32, 10i32);
         assert!(!a.intersects(&b));
     }
 
     #[test]
-    fn intersects_false_when_one_is_empty() {
+    fn test_intersects_false_when_one_is_empty() {
         let a = Interval::new(1i32, 5i32);
         let empty = Interval::new(3i32, 3i32);
         assert!(!a.intersects(&empty));
@@ -748,27 +748,27 @@ mod tests {
     }
 
     #[test]
-    fn intersects_true_with_itself_if_non_empty() {
+    fn test_intersects_true_with_itself_if_non_empty() {
         let a = Interval::new(1i32, 5i32);
         assert!(a.intersects(&a));
     }
 
     #[test]
-    fn intersection_returns_overlap_interval() {
+    fn test_intersection_returns_overlap_interval() {
         let a = Interval::new(0i32, 10i32);
         let b = Interval::new(5i32, 15i32);
         assert_eq!(a.intersection(&b), Some(Interval::new(5, 10)));
     }
 
     #[test]
-    fn intersection_is_none_when_touching_at_endpoint() {
+    fn test_intersection_is_none_when_touching_at_endpoint() {
         let a = Interval::new(0i32, 10i32);
         let b = Interval::new(10i32, 20i32);
         assert_eq!(a.intersection(&b), None);
     }
 
     #[test]
-    fn intersection_with_empty_is_none() {
+    fn test_intersection_with_empty_is_none() {
         let a = Interval::new(1i32, 5i32);
         let empty = Interval::new(3i32, 3i32);
         assert_eq!(a.intersection(&empty), None);
@@ -776,57 +776,57 @@ mod tests {
     }
 
     #[test]
-    fn intersection_with_itself_yields_self() {
+    fn test_intersection_with_itself_yields_self() {
         let a = Interval::new(2i32, 7i32);
         assert_eq!(a.intersection(&a), Some(a));
     }
 
     #[test]
-    fn clamp_to_inner_boundary_returns_inner() {
+    fn test_clamp_to_inner_boundary_returns_inner() {
         let a = Interval::new(0i32, 10i32);
         let boundary = Interval::new(2i32, 8i32);
         assert_eq!(a.clamp(&boundary), Some(boundary));
     }
 
     #[test]
-    fn clamp_disjoint_returns_none() {
+    fn test_clamp_disjoint_returns_none() {
         let a = Interval::new(0i32, 3i32);
         let boundary = Interval::new(5i32, 7i32);
         assert_eq!(a.clamp(&boundary), None);
     }
 
     #[test]
-    fn clamp_to_equal_returns_self() {
+    fn test_clamp_to_equal_returns_self() {
         let a = Interval::new(2i32, 6i32);
         assert_eq!(a.clamp(&a), Some(a));
     }
 
     #[test]
-    fn length_on_signed_integers() {
+    fn test_length_on_signed_integers() {
         let i = Interval::new(-3i32, 2i32);
         assert_eq!(i.length(), 5);
     }
 
     #[test]
-    fn length_on_unsigned_integers() {
+    fn test_length_on_unsigned_integers() {
         let i = Interval::new(3u32, 9u32);
         assert_eq!(i.length(), 6);
     }
 
     #[test]
-    fn midpoint_on_even_integer_span() {
+    fn test_midpoint_on_even_integer_span() {
         let i = Interval::new(2i32, 6i32);
         assert_eq!(i.midpoint(), 4);
     }
 
     #[test]
-    fn midpoint_on_odd_integer_span_floor_behavior() {
+    fn test_midpoint_on_odd_integer_span_floor_behavior() {
         let i = Interval::new(0i32, 3i32);
         assert_eq!(i.midpoint(), 1);
     }
 
     #[test]
-    fn midpoint_integer_avoids_overflow_where_a_plus_b_would() {
+    fn test_midpoint_integer_avoids_overflow_where_a_plus_b_would() {
         let a = i64::MAX - 2;
         let b = i64::MAX;
         let i = Interval::new(a, b);
@@ -834,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn midpoint_on_floats_basic() {
+    fn test_midpoint_on_floats_basic() {
         let i = Interval::new(1.0f64, 3.0f64);
         assert_eq!(i.midpoint(), 2.0);
         let j = Interval::new(-10.0f32, 6.0f32);
@@ -842,33 +842,33 @@ mod tests {
     }
 
     #[test]
-    fn to_range_roundtrip() {
+    fn test_to_range_roundtrip() {
         let i = Interval::new(-2i32, 5i32);
         let r = i.to_range();
         assert_eq!(r, -2..5);
     }
 
     #[test]
-    fn from_range_normalizes_order() {
+    fn test_from_range_normalizes_order() {
         let i: Interval<i32> = (5..2).into();
         assert_eq!(i.start(), 2);
         assert_eq!(i.end(), 5);
     }
 
     #[test]
-    fn display_formats_as_half_open() {
+    fn test_display_formats_as_half_open() {
         let i = Interval::new(1i32, 5i32);
         assert_eq!(format!("{}", i), "[1, 5)");
     }
 
     #[test]
-    fn display_formats_empty() {
+    fn test_display_formats_empty() {
         let i = Interval::new(5i32, 5i32);
         assert_eq!(format!("{}", i), "[5, 5)");
     }
 
     #[test]
-    fn hash_and_eq_allow_dedup_in_set() {
+    fn test_hash_and_eq_allow_dedup_in_set() {
         let mut set = HashSet::new();
         set.insert(Interval::new(5i32, 3i32));
         set.insert(Interval::new(3i32, 5i32));
@@ -877,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    fn contains_interval_with_empty_self_is_true_only_if_other_is_also_empty_and_equal() {
+    fn test_contains_interval_with_empty_self_is_true_only_if_other_is_also_empty_and_equal() {
         let empty = Interval::new(4i32, 4i32);
         let empty_same = Interval::new(4i32, 4i32);
         let non_empty = Interval::new(3i32, 5i32);
@@ -886,54 +886,54 @@ mod tests {
     }
 
     #[test]
-    fn floats_infinite_bounds_midpoint_is_nan() {
+    fn test_floats_infinite_bounds_midpoint_is_nan() {
         let i = Interval::new(f64::NEG_INFINITY, f64::INFINITY);
         assert!(i.midpoint().is_nan());
     }
 
     #[test]
-    fn contains_interval_with_empty_other_at_edges() {
+    fn test_contains_interval_with_empty_other_at_edges() {
         let a = Interval::new(1i32, 5i32);
         assert!(a.contains_interval(&Interval::new(1, 1)));
         assert!(a.contains_interval(&Interval::new(5, 5)));
     }
 
     #[test]
-    fn from_range_via_into_needs_parens() {
+    fn test_from_range_via_into_needs_parens() {
         let i: Interval<_> = (1..5).into();
         assert_eq!((i.start(), i.end()), (1, 5));
     }
 
     #[test]
     #[should_panic(expected = "step must be > 0")]
-    fn iter_panics_on_zero_step_int() {
+    fn test_iter_panics_on_zero_step_int() {
         let i = Interval::new(1i32, 5i32);
         let _ = i.iter(0).next();
     }
 
     #[test]
     #[should_panic(expected = "step must be > 0")]
-    fn iter_panics_on_negative_step_int() {
+    fn test_iter_panics_on_negative_step_int() {
         let i = Interval::new(1i32, 5i32);
         let _ = i.iter(-1).next();
     }
 
     #[test]
-    fn iter_basic_progression() {
+    fn test_iter_basic_progression() {
         let i = Interval::new(1i32, 5i32);
         let v: Vec<_> = i.iter(1).collect();
         assert_eq!(v, vec![1, 2, 3, 4]); // half-open
     }
 
     #[test]
-    fn iter_step_larger_than_span_emits_once_if_non_empty() {
+    fn test_iter_step_larger_than_span_emits_once_if_non_empty() {
         let i = Interval::new(1i32, 5i32);
         let v: Vec<_> = i.iter(10).collect();
         assert_eq!(v, vec![1]);
     }
 
     #[test]
-    fn iter_over_empty_is_empty() {
+    fn test_iter_over_empty_is_empty() {
         let i = Interval::new(3i32, 3i32);
         assert_eq!(i.iter(1).next(), None);
     }

--- a/crates/dock-alloc-core/src/primitives.rs
+++ b/crates/dock-alloc-core/src/primitives.rs
@@ -260,6 +260,74 @@ impl<T> Interval<T> {
         start < end
     }
 
+    /// Translates the interval by a given distance.
+    ///
+    /// This method creates a new interval by adding a distance `d`
+    /// to both the start and end points of the current interval.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_core::primitives::Interval;
+    ///
+    /// let interval = Interval::new(1, 5);
+    /// let translated = interval.translate(2);
+    /// assert_eq!(translated.start(), 3); // start is now 1 + 2
+    /// assert_eq!(translated.end(), 7);   // end is now 5 +
+    /// ```
+    #[inline]
+    pub fn translate(&self, d: T) -> Self
+    where
+        T: Copy + PartialOrd + Add<Output = T>,
+    {
+        Self::new(self.start() + d, self.end() + d)
+    }
+
+    /// Inflates the interval by a given distance.
+    ///
+    /// This method creates a new interval by subtracting `d` from the start point
+    /// and adding `d` to the end point of the current interval.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_core::primitives::Interval;
+    ///
+    /// let interval = Interval::new(1, 5);
+    /// let inflated = interval.inflate(2);
+    /// assert_eq!(inflated.start(), -1); // start is now 1 - 2
+    /// assert_eq!(inflated.end(), 7);   // end is now 5 + 2
+    /// ```
+    #[inline]
+    pub fn inflate(&self, d: T) -> Self
+    where
+        T: Copy + PartialOrd + Sub<Output = T> + Add<Output = T>,
+    {
+        Self::new(self.start() - d, self.end() + d)
+    }
+
+    /// Measures the length of the interval.
+    ///
+    /// This method calculates the length of the interval as the difference between
+    /// `end_exclusive` and `start_inclusive`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_core::primitives::Interval;
+    ///
+    /// let interval = Interval::new(2, 5);
+    /// assert_eq!(interval.measure(), 3); // length is 5 - 2
+    /// let empty_interval = Interval::new(5, 5);
+    /// assert_eq!(empty_interval.measure(), 0); // length is 0 for empty
+    /// ```
+    pub fn measure<D>(&self) -> D
+    where
+        T: Copy + Sub<Output = D>,
+    {
+        self.end() - self.start()
+    }
+
     /// Returns the intersection of this interval with another interval.
     ///
     /// This method returns an `Option<Interval<T>>` that represents the

--- a/crates/dock-alloc-model/Cargo.toml
+++ b/crates/dock-alloc-model/Cargo.toml
@@ -19,6 +19,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-[workspace]
-resolver = "2"
-members = ["crates/dock-alloc-core", "crates/dock-alloc-model"]
+[package]
+name = "dock_alloc_model"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+dock_alloc_core = { path = "../dock-alloc-core" }
+num-traits = "0.2.19"

--- a/crates/dock-alloc-model/README.md
+++ b/crates/dock-alloc-model/README.md
@@ -1,0 +1,121 @@
+# dock-alloc-model
+
+A foundational Rust crate providing validated, type-safe data structures for the **Berth Allocation Problem (BAP)**.
+
+`dock-alloc-model` defines the core entities of a berth allocation scenario: `Request`s for quay space, the `Problem` to be solved, and the final `Solution`. It is designed to be a solver-agnostic layer, allowing developers to focus on building optimization algorithms (e.g., heuristics, MILP, CP) without worrying about the integrity and correctness of the underlying data model.
+
+## Key Features
+
+-   **Type-Safe Primitives**: Uses strong types from the `dock-alloc-core` crate like `RequestId`, `SpaceLength`, and `TimePoint` to prevent common bugs with primitive types.
+-   **Comprehensive `Request` Model**: Captures a wide range of real-world constraints, including vessel length, processing duration, feasible time/space windows, target positions, and costs for delay, deviation, and dropping.
+-   **Abstract by Design**: A `Request` is not just for ships! The model is flexible enough to represent any space-time constraint. For example, it can model a **maintenance window** by creating a request with zero cost and a hard feasibility constraint, which is then `PreAssigned` in the problem.
+-   **Rigorous Validation**: The `Problem` and `Solution` constructors perform exhaustive checks to ensure logical consistency. This includes detecting overlaps between pre-assignments, assignments outside quay boundaries, violations of feasibility windows, and more. This saves solver developers from writing complex and error-prone validation logic.
+-   **Solver-Agnostic**: The model makes no assumptions about the optimization technique used. It serves as a pure data layer for any kind of solver.
+-   **Generic & Flexible**: Uses generic types for time (`TimeType`) and cost (`CostType`), allowing for the use of `i64`, floating-point types, or custom high-precision numeric types.
+
+## Core Components
+
+The crate revolves around a few central structs:
+
+1.  **`Request<TimeType, CostType>`**: Represents a single requirement for a space-time slot. It holds all the physical, temporal, and cost-related parameters for one booking.
+
+2.  **`Problem<TimeType, CostType>`**: Defines a complete, validated scenario. It contains:
+    -   A set of all `Request`s.
+    -   A set of `ProblemEntry`s, which specify whether a request is `Unassigned` (needs scheduling) or `PreAssigned` (already fixed in place).
+    -   The total `quay_length`.
+
+3.  **`Solution<TimeType, CostType>`**: Represents a complete and validated solution to a `Problem`. It contains:
+    -   A `Decision` for each request (`Assign` or `Drop`).
+    -   `SolutionStats` with aggregated metrics like total cost, total waiting time, and number of dropped requests.
+
+## Usage Example
+
+Here's how to define a problem with two requests—one to be scheduled and one representing a fixed maintenance window—and then create a valid solution for it.
+
+```rust
+use std::collections::HashSet;
+use dock_alloc_core::domain::{
+    Cost, SpaceInterval, SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint,
+};
+use dock_alloc_model::{
+    Problem, ProblemEntry, Request, RequestId, Solution, Decision, Assignment
+};
+
+// --- 1. Define the Requests ---
+
+// A standard vessel request that needs to be scheduled.
+let vessel_request = Request::new(
+    RequestId::new(1),
+    SpaceLength::new(150),      // 150m long
+    TimeDelta::new(3600 * 4),   // needs 4 hours
+    SpacePosition::new(200),    // prefers position 200m
+    Cost::new(50),              // cost per second of delay
+    Cost::new(10),              // cost per meter of deviation
+    TimeInterval::new(TimePoint::new(0), TimePoint::new(3600 * 24)),
+    SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(800)),
+    None, // This request cannot be dropped
+).unwrap();
+
+// A request representing a pre-scheduled maintenance block.
+// It has no costs and a very specific time/space window.
+let maintenance_request = Request::new(
+    RequestId::new(2),
+    SpaceLength::new(100),      // Maintenance area is 100m
+    TimeDelta::new(3600 * 2),   // Lasts 2 hours
+    SpacePosition::new(400),    // Target position (not relevant due to pre-assignment)
+    Cost::new(0),               // No cost
+    Cost::new(0),               // No cost
+    TimeInterval::new(TimePoint::new(3600 * 6), TimePoint::new(3600 * 8)),
+    SpaceInterval::new(SpacePosition::new(400), SpacePosition::new(500)),
+    None,
+).unwrap();
+
+
+// --- 2. Create the Problem ---
+
+let requests = HashSet::from([vessel_request, maintenance_request]);
+
+let entries = HashSet::from([
+    // The vessel is unassigned and needs a schedule.
+    ProblemEntry::Unassigned(RequestId::new(1)),
+    // The maintenance is pre-assigned to a fixed time and place.
+    ProblemEntry::PreAssigned(Assignment::new(
+        RequestId::new(2),
+        SpacePosition::new(400),
+        TimePoint::new(3600 * 6), // Starts exactly 6 hours in
+    )),
+]);
+
+let quay_length = SpaceLength::new(1000);
+let problem = Problem::new(requests, entries, quay_length).unwrap();
+
+
+// --- 3. Define a Solution from a Solver's Output ---
+
+// Assume our solver decides to place the vessel right at the start of the quay
+// immediately at its arrival time.
+let solver_decisions = vec![
+    Decision::Assign(Assignment::new(
+        RequestId::new(1),
+        SpacePosition::new(0),
+        TimePoint::new(0), // No waiting time
+    ))
+];
+
+// The Solution constructor will validate these decisions against the problem.
+// It automatically includes the pre-assigned entries.
+let solution = Solution::new(&problem, solver_decisions).unwrap();
+
+
+// --- 4. Analyze the Solution ---
+
+println!("Solution is valid!");
+println!("Total cost: {}", solution.stats().total_cost()); // waiting_cost(0) + deviation_cost(200)
+println!("Total waiting time: {}", solution.stats().total_waiting_time());
+
+let vessel1_decision = solution.decisions().get(&RequestId::new(1)).unwrap();
+println!("Decision for vessel 1: {:?}", vessel1_decision);
+
+// Cost should be 0 (waiting) + (200 * 10) = 2000
+assert_eq!(solution.stats().total_cost().value(), 2000);
+```

--- a/crates/dock-alloc-model/src/lib.rs
+++ b/crates/dock-alloc-model/src/lib.rs
@@ -141,6 +141,37 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
+    /// Compares two `Vessel` instances for equality based on their unique identifiers.
+    ///
+    /// This implementation checks if the `id` of one vessel is equal to the `id` of another vessel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel1 = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// let vessel2 = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(200),
+    ///     TimePoint::new(3), // Example timestamp
+    ///     TimeDelta::new(2), // Example duration in seconds
+    ///     SpacePosition::new(1),
+    ///     Cost::new(300), // Example cost per waiting time
+    ///     Cost::new(500), // Example cost per target berthing deviation
+    /// );
+    /// assert!(vessel1 == vessel2);
+    /// ```
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
@@ -158,6 +189,45 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
+    /// Computes the hash of the `Vessel` based on its unique identifier.
+    ///
+    /// This implementation hashes the `id` of the vessel, allowing it to be used in hash-based collections.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::hash::{Hash, Hasher};
+    /// use std::collections::hash_map::DefaultHasher;
+    /// use std::collections::HashSet;
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel1 = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// let vessel2 = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(200),
+    ///     TimePoint::new(3), // Example timestamp
+    ///     TimeDelta::new(2), // Example duration in seconds
+    ///     SpacePosition::new(1),
+    ///     Cost::new(300), // Example cost per waiting time
+    ///     Cost::new(500), // Example cost per target berthing deviation
+    /// );
+    /// let mut h1 = DefaultHasher::new();
+    /// vessel1.hash(&mut h1);
+    /// let mut h2 = DefaultHasher::new();
+    /// vessel2.hash(&mut h2);
+    /// assert_eq!(h1.finish(), h2.finish());
+    /// ```
+    #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
     }
@@ -168,6 +238,43 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
+    /// Compares two `Vessel` instances for ordering based on their unique identifiers.
+    ///
+    /// This implementation allows for partial ordering of vessels, primarily based on their `id`.
+    ///
+    /// # Note
+    ///
+    /// You might expect ordering based on the arrival time or other attributes,
+    /// but this implementation only considers the `id` for simplicity. You need
+    /// to implement additional logic if you want to compare vessels based on other attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel1 = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// let vessel2 = Vessel::new(
+    ///     VesselId::new(2),
+    ///     SpaceLength::new(200),
+    ///     TimePoint::new(3), // Example timestamp
+    ///     TimeDelta::new(2), // Example duration in seconds
+    ///     SpacePosition::new(1),
+    ///     Cost::new(300), // Example cost per waiting time
+    ///     Cost::new(500), // Example cost per target berthing deviation
+    /// );
+    /// assert!(vessel1 < vessel2);
+    /// ```
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -178,6 +285,43 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
+    /// Compares two `Vessel` instances for total ordering based on their unique identifiers.
+    ///
+    /// This implementation allows for total ordering of vessels, primarily based on their `id`.
+    ///
+    /// # Note
+    ///
+    /// You might expect ordering based on the arrival time or other attributes,
+    /// but this implementation only considers the `id` for simplicity. You need
+    /// to implement additional logic if you want to compare vessels based on other attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel1 = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// let vessel2 = Vessel::new(
+    ///     VesselId::new(2),
+    ///     SpaceLength::new(200),
+    ///     TimePoint::new(3), // Example timestamp
+    ///     TimeDelta::new(2), // Example duration in seconds
+    ///     SpacePosition::new(1),
+    ///     Cost::new(300), // Example cost per waiting time
+    ///     Cost::new(500), // Example cost per target berthing deviation
+    /// );
+    /// assert!(vessel1 < vessel2);
+    /// ```
+    #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.id.cmp(&other.id)
     }
@@ -216,6 +360,7 @@ where
     /// assert_eq!(vessel.cost_per_waiting_time(), Cost::new(10));
     /// assert_eq!(vessel.cost_per_target_berthing_deviation(), Cost::new(5));
     /// ```
+    #[inline]
     pub fn new(
         id: VesselId,
         length: SpaceLength,
@@ -309,6 +454,7 @@ where
     /// );
     /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
     /// ```
+    #[inline]
     pub fn arrival_time(&self) -> TimePoint<TimeType> {
         self.arrival_time
     }
@@ -334,6 +480,7 @@ where
     /// );
     /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
     /// ```
+    #[inline]
     pub fn processing_duration(&self) -> TimeDelta<TimeType> {
         self.processing_duration
     }
@@ -359,6 +506,7 @@ where
     /// );
     /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
     /// ```
+    #[inline]
     pub fn target_berthing_position(&self) -> SpacePosition {
         self.target_berthing_position
     }
@@ -384,6 +532,7 @@ where
     /// );
     /// assert_eq!(vessel.cost_per_waiting_time().value(), 10);
     /// ```
+    #[inline]
     pub fn cost_per_waiting_time(&self) -> Cost<CostType> {
         self.cost_per_waiting_time
     }
@@ -409,8 +558,96 @@ where
     /// );
     /// assert_eq!(vessel.cost_per_target_berthing_deviation().value(), 5);
     /// ```
+    #[inline]
     pub fn cost_per_target_berthing_deviation(&self) -> Cost<CostType> {
         self.cost_per_target_berthing_deviation
+    }
+}
+
+impl<TimeType, CostType> Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed + TryFrom<TimeType>,
+{
+    /// Calculates the cost incurred by the vessel for waiting time.
+    ///
+    /// This function computes the cost based on the waiting time provided as a `TimeDelta`.
+    /// It multiplies the waiting time by the cost per waiting time to determine the total cost.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the waiting time does not fit into the `CostType` and a conversion
+    /// would result in an overflow or underflow.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// let waiting_time = TimeDelta::new(2); // Example waiting time in seconds
+    /// let cost = vessel.waiting_cost(waiting_time);
+    /// assert_eq!(cost.value(), 20); // 10 * 2
+    /// ```
+    #[inline]
+    pub fn waiting_cost(&self, waiting_time: TimeDelta<TimeType>) -> Cost<CostType> {
+        let scalar: CostType = CostType::try_from(waiting_time.value())
+            .ok()
+            .expect("waiting time does not fit in CostType");
+        self.cost_per_waiting_time * scalar
+    }
+}
+
+impl<TimeType, CostType> Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed + TryFrom<usize>,
+{
+    /// Calculates the cost incurred by the vessel for deviations from the target berthing position.
+    ///
+    /// This function computes the cost based on the deviation from the target berthing position
+    /// provided as a `SpaceLength`. It multiplies the deviation by the cost per target berthing deviation
+    /// to determine the total cost.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the deviation does not fit into the `CostType` and a conversion
+    /// would result in an overflow or underflow.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// let deviation = SpaceLength::new(3); // Example deviation in length
+    /// let cost = vessel.target_berthing_deviation_cost(deviation);
+    /// assert_eq!(cost.value(), 15); // 5 * 3
+    /// ```
+    #[inline]
+    pub fn target_berthing_deviation_cost(&self, deviation: SpaceLength) -> Cost<CostType> {
+        let scalar: CostType = CostType::try_from(deviation.value())
+            .ok()
+            .expect("deviation does not fit in CostType");
+        self.cost_per_target_berthing_deviation * scalar
     }
 }
 
@@ -623,7 +860,7 @@ mod tests {
     }
 
     #[test]
-    fn vessels_are_unique_by_id() {
+    fn test_vessels_are_unique_by_id() {
         let mut set = std::collections::HashSet::new();
         let v1 = Vessel::new(
             VesselId::new(1),
@@ -647,5 +884,37 @@ mod tests {
         set.insert(v1);
         set.insert(v2);
         assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_waiting_cost() {
+        let vessel = Vessel::new(
+            VesselId::new(1),
+            SpaceLength::new(100),
+            TimePoint::new(1622547800),
+            TimeDelta::new(3600),
+            SpacePosition::new(50),
+            Cost::new(10),
+            Cost::new(5),
+        );
+        let waiting_time = TimeDelta::new(2);
+        let cost = vessel.waiting_cost(waiting_time);
+        assert_eq!(cost.value(), 20); // 10 * 2
+    }
+
+    #[test]
+    fn test_target_berthing_deviation_cost() {
+        let vessel = Vessel::new(
+            VesselId::new(1),
+            SpaceLength::new(100),
+            TimePoint::new(1622547800),
+            TimeDelta::new(3600),
+            SpacePosition::new(50),
+            Cost::new(10),
+            Cost::new(5),
+        );
+        let deviation = SpaceLength::new(3);
+        let cost = vessel.target_berthing_deviation_cost(deviation);
+        assert_eq!(cost.value(), 15); // 5 * 3
     }
 }

--- a/crates/dock-alloc-model/src/lib.rs
+++ b/crates/dock-alloc-model/src/lib.rs
@@ -694,6 +694,248 @@ where
     }
 }
 
+/// Represents an assignment of a vessel to a berthing position and time.
+///
+/// This struct encapsulates the details of a vessel's assignment, including the vessel itself,
+/// the berthing position along the quay, and the berthing time.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{Assignment, VesselId};
+/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+///
+/// let assignment = Assignment::new(
+///     VesselId::new(1),
+///     SpacePosition::new(100),
+///     TimePoint::new(1622547800)
+/// );
+/// assert_eq!(assignment.vessel_id(), VesselId::new(1));
+/// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
+/// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Assignment<TimeType = i64>
+where
+    TimeType: PrimInt + Signed,
+{
+    vessel_id: VesselId,
+    berthing_position: SpacePosition,
+    berthing_time: TimePoint<TimeType>,
+}
+
+impl<TimeType> Assignment<TimeType>
+where
+    TimeType: PrimInt + Signed,
+{
+    /// Creates a new `Assignment` instance with the specified parameters.
+    ///
+    /// This function initializes an `Assignment` with the vessel's unique identifier,
+    /// the berthing position along the quay, and the berthing time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Assignment, VesselId};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    ///
+    /// let assignment = Assignment::new(
+    ///     VesselId::new(1),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1622547800)
+    /// );
+    /// assert_eq!(assignment.vessel_id(), VesselId::new(1));
+    /// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
+    /// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+    /// ```
+    #[inline]
+    pub fn new(
+        vessel_id: VesselId,
+        berthing_position: SpacePosition,
+        berthing_time: TimePoint<TimeType>,
+    ) -> Self {
+        Assignment {
+            vessel_id,
+            berthing_position,
+            berthing_time,
+        }
+    }
+
+    /// Returns the unique identifier of the vessel associated with the assignment.
+    ///
+    /// This function retrieves the `VesselId` of the vessel that has
+    /// been assigned to a specific berthing position and time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Assignment, VesselId};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    ///
+    /// let assignment = Assignment::new(
+    ///     VesselId::new(1),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1622547800)
+    /// );
+    /// assert_eq!(assignment.vessel_id(), VesselId::new(1));
+    /// ```
+    #[inline]
+    pub fn vessel_id(&self) -> VesselId {
+        self.vessel_id
+    }
+
+    /// Returns the berthing position of the vessel.
+    ///
+    /// This function retrieves the `SpacePosition` along the
+    /// quay where the vessel is assigned to berth.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Assignment, VesselId};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    ///
+    /// let assignment = Assignment::new(
+    ///     VesselId::new(1),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1622547800)
+    /// );
+    /// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
+    /// ```
+    #[inline]
+    pub fn berthing_position(&self) -> SpacePosition {
+        self.berthing_position
+    }
+
+    /// Returns the berthing time of the vessel.
+    ///
+    /// This function retrieves the `TimePoint` representing
+    /// when the vessel is scheduled to berth.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Assignment, VesselId};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    ///
+    /// let assignment = Assignment::new(
+    ///     VesselId::new(1),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1622547800)
+    /// );
+    /// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+    /// ```
+    #[inline]
+    pub fn berthing_time(&self) -> TimePoint<TimeType> {
+        self.berthing_time
+    }
+}
+
+impl<TimeType> Display for Assignment<TimeType>
+where
+    TimeType: PrimInt + Signed + Display,
+{
+    /// Formats the `Assignment` for display.
+    ///
+    /// This implementation provides a string representation of the `Assignment`
+    /// including the vessel identifier, berthing position, and berthing time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Assignment, VesselId};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    ///
+    /// let assignment = Assignment::new(
+    ///     VesselId::new(1),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1622547800)
+    /// );
+    /// println!("{}", assignment);
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Assignment(vessel_id: {}, berthing_position: {}, berthing_time: {})",
+            self.vessel_id, self.berthing_position, self.berthing_time
+        )
+    }
+}
+
+/// Represents an entry in the Berthing Allocation Problem.
+///
+/// This enum distinguishes between vessels that are unassigned and those
+/// that have been pre-assigned specific berthing positions and times.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{ProblemEntry, Assignment, VesselId};
+/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+///
+/// let unassigned: ProblemEntry<i64> = ProblemEntry::Unassigned(VesselId::new(1));
+/// let pre_assigned: ProblemEntry<i64> = ProblemEntry::PreAssigned(Assignment::new(
+///     VesselId::new(2),
+///     SpacePosition::new(100),
+///     TimePoint::new(1622547800)
+/// ));
+/// assert!(matches!(unassigned, ProblemEntry::Unassigned(_)));
+/// assert!(matches!(pre_assigned, ProblemEntry::PreAssigned(_)));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ProblemEntry<TimeType = i64>
+where
+    TimeType: PrimInt + Signed,
+{
+    /// A vessel that has not been assigned a berthing position or time.
+    ///
+    /// This variant holds the `VesselId` of the unassigned vessel.
+    /// The solver can decide freely where and when to berth this vessel.
+    Unassigned(VesselId),
+
+    /// A vessel that has been pre-assigned a specific berthing position and time.
+    ///
+    /// This variant holds an `Assignment` struct containing the details of the pre-assignment.
+    /// The solver must respect this assignment and cannot change it.
+    PreAssigned(Assignment<TimeType>),
+}
+
+impl<TimeType> Display for ProblemEntry<TimeType>
+where
+    TimeType: PrimInt + Signed + Display,
+{
+    /// Formats the `ProblemEntry` for display.
+    ///
+    /// This implementation provides a string representation of the `ProblemEntry`
+    /// indicating whether it is an unassigned vessel or a pre-assigned vessel with its details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{ProblemEntry, Assignment, VesselId};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    ///
+    /// let unassigned: ProblemEntry<i64> = ProblemEntry::Unassigned(VesselId::new(1));
+    /// let pre_assigned: ProblemEntry<i64> = ProblemEntry::PreAssigned(Assignment::new(
+    ///     VesselId::new(2),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1622547800)
+    /// ));
+    /// println!("{}", unassigned);
+    /// println!("{}", pre_assigned);
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProblemEntry::Unassigned(vessel_id) => {
+                write!(f, "Unassigned(vessel_id: {})", vessel_id)
+            }
+            ProblemEntry::PreAssigned(assignment) => {
+                write!(f, "PreAssigned({})", assignment)
+            }
+        }
+    }
+}
+
 /// Represents the Berthing Allocation Problem.
 ///
 /// This struct encapsulates the problem's vessels and the quay length available for berthing.
@@ -705,6 +947,7 @@ where
     CostType: PrimInt + Signed,
 {
     vessels: HashSet<Vessel<TimeType, CostType>>,
+    entries: HashSet<ProblemEntry<TimeType>>,
     quay_length: SpaceLength,
 }
 
@@ -721,18 +964,24 @@ where
     ///
     /// ```
     /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Problem, VesselId};
+    /// use dock_alloc_model::{ProblemEntry, Problem, VesselId};
     /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
     ///
     /// let vessels = HashSet::new();
+    /// let entries = HashSet::new();
     /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
     /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
     /// ```
     #[inline]
-    pub fn new(vessels: HashSet<Vessel<TimeType, CostType>>, quay_length: SpaceLength) -> Self {
+    pub fn new(
+        vessels: HashSet<Vessel<TimeType, CostType>>,
+        entries: HashSet<ProblemEntry<TimeType>>,
+        quay_length: SpaceLength,
+    ) -> Self {
         Problem {
             vessels,
+            entries,
             quay_length,
         }
     }
@@ -745,12 +994,13 @@ where
     ///
     /// ```
     /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Problem, VesselId};
+    /// use dock_alloc_model::{ProblemEntry, Problem, VesselId};
     /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
     ///
     /// let vessels = HashSet::new();
+    /// let entries = HashSet::new();
     /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
     /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
     /// ```
     #[inline]
@@ -766,17 +1016,41 @@ where
     ///
     /// ```
     /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Problem, Vessel, VesselId};
+    /// use dock_alloc_model::{ProblemEntry, Problem, Vessel, VesselId};
     /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
     ///
     /// let vessels = HashSet::new();
+    /// let entries = HashSet::new();
     /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
     /// assert!(problem.vessels().is_empty());
     /// ```
     #[inline]
     pub fn vessels(&self) -> &HashSet<Vessel<TimeType, CostType>> {
         &self.vessels
+    }
+
+    /// Returns a reference to the set of problem entries.
+    ///
+    /// This function provides access to the `HashSet` of problem entries,
+    /// allowing iteration or inspection of the entries involved in the problem.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use dock_alloc_model::{ProblemEntry, Problem, Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessels = HashSet::new();
+    /// let entries = HashSet::new();
+    /// let quay_length = SpaceLength::new(1000);
+    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
+    /// assert!(problem.entries().is_empty());
+    /// ```
+    #[inline]
+    pub fn entries(&self) -> &HashSet<ProblemEntry<TimeType>> {
+        &self.entries
     }
 
     /// Returns the number of vessels in the problem.
@@ -791,8 +1065,9 @@ where
     /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
     ///
     /// let vessels = HashSet::new();
+    /// let entries = HashSet::new();
     /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
     /// assert_eq!(problem.vessel_len(), 0);
     /// ```
     #[inline]
@@ -916,5 +1191,20 @@ mod tests {
         let deviation = SpaceLength::new(3);
         let cost = vessel.target_berthing_deviation_cost(deviation);
         assert_eq!(cost.value(), 15); // 5 * 3
+    }
+
+    #[test]
+    fn test_assignment_display() {
+        let assignment = Assignment::new(
+            VesselId::new(1),
+            SpacePosition::new(100),
+            TimePoint::new(1622547800),
+        );
+        assert_eq!(
+            format!("{}", assignment),
+            "Assignment(vessel_id: VesselId(1), \
+            berthing_position: SpacePosition(100), \
+            berthing_time: TimePoint(1622547800))"
+        );
     }
 }

--- a/crates/dock-alloc-model/src/lib.rs
+++ b/crates/dock-alloc-model/src/lib.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 Felix Kahle.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#[allow(dead_code)]
+use std::fmt::Display;
+
+/// Represents a unique identifier for a vessel.
+///
+/// This identifier is used to track vessels in the system.
+/// It is a wrapper around a `u64` value, providing methods to create and access
+/// the identifier value.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::VesselId;
+///
+/// let vessel_id = VesselId::new(12345);
+/// assert_eq!(vessel_id.value(), 12345);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct VesselId(u64);
+
+impl VesselId {
+    /// Creates a new `VesselId` with the given identifier value.
+    ///
+    /// This function creates a new `VesselId` instance with the specified `u64` value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::VesselId;
+    ///
+    /// let id = VesselId::new(42);
+    /// assert_eq!(id.value(), 42);
+    /// ```
+    #[inline]
+    pub const fn new(id: u64) -> Self {
+        VesselId(id)
+    }
+
+    /// Returns the underlying `u64` value of the `VesselId`.
+    ///
+    /// This function retrieves the `u64` value that the `VesselId` wraps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::VesselId;
+    ///
+    /// let id = VesselId::new(42);
+    /// assert_eq!(id.value(), 42);
+    /// ```
+    #[inline]
+    pub const fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for VesselId {
+    /// Formats the `VesselId` for display.
+    ///
+    /// This implementation provides a string representation of the `VesselId`
+    /// in the format `VesselId(value)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::VesselId;
+    ///
+    /// let id = VesselId::new(42);
+    /// assert_eq!(format!("{}", id), "VesselId(42)");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "VesselId({})", self.0)
+    }
+}
+
+impl From<u64> for VesselId {
+    /// Converts a `u64` value into a `VesselId`.
+    ///
+    /// This implementation allows for easy conversion from a `u64` to a `VesselId`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::VesselId;
+    ///
+    /// let id: VesselId = 42.into();
+    /// assert_eq!(id.value(), 42);
+    /// ```
+    fn from(value: u64) -> Self {
+        VesselId(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vessel_id_creation() {
+        let id = VesselId::new(42);
+        assert_eq!(id.value(), 42);
+    }
+
+    #[test]
+    fn test_vessel_id_display() {
+        let id = VesselId::new(42);
+        assert_eq!(format!("{}", id), "VesselId(42)");
+    }
+
+    #[test]
+    fn test_vessel_id_equality() {
+        let id1 = VesselId::new(42);
+        let id2 = VesselId::new(42);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_vessel_id_from_u64() {
+        let id: VesselId = 42.into();
+        assert_eq!(id.value(), 42);
+    }
+}

--- a/crates/dock-alloc-model/src/lib.rs
+++ b/crates/dock-alloc-model/src/lib.rs
@@ -21,6 +21,10 @@
 
 #[allow(dead_code)]
 use std::fmt::Display;
+use std::{collections::HashSet, hash::Hash};
+
+use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+use num_traits::{PrimInt, Signed};
 
 /// Represents a unique identifier for a vessel.
 ///
@@ -112,6 +116,460 @@ impl From<u64> for VesselId {
     }
 }
 
+/// Represents a vessel in the Berthing Allocation Problem.
+///
+/// This struct encapsulates all the necessary information about a vessel,
+/// including its unique identifier, length, arrival time, processing duration,
+/// target berthing position, and associated costs.
+#[derive(Debug, Clone, Copy)]
+pub struct Vessel<TimeType = i64, CostType = i64>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    id: VesselId,
+    length: SpaceLength,
+    arrival_time: TimePoint<TimeType>,
+    processing_duration: TimeDelta<TimeType>,
+    target_berthing_position: SpacePosition,
+    cost_per_waiting_time: Cost<CostType>,
+    cost_per_target_berthing_deviation: Cost<CostType>,
+}
+
+impl<TimeType, CostType> PartialEq for Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<TimeType, CostType> Eq for Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+}
+
+impl<TimeType, CostType> Hash for Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl<TimeType, CostType> PartialOrd for Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<TimeType, CostType> Ord for Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl<TimeType, CostType> Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    /// Creates a new `Vessel` instance with the specified parameters.
+    ///
+    /// This function initializes a `Vessel` with its unique identifier, length,
+    /// arrival time, processing duration, target berthing position, and cost parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.id(), VesselId::new(1));
+    /// assert_eq!(vessel.length(), SpaceLength::new(100));
+    /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
+    /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
+    /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
+    /// assert_eq!(vessel.cost_per_waiting_time(), Cost::new(10));
+    /// assert_eq!(vessel.cost_per_target_berthing_deviation(), Cost::new(5));
+    /// ```
+    pub fn new(
+        id: VesselId,
+        length: SpaceLength,
+        arrival_time: TimePoint<TimeType>,
+        processing_duration: TimeDelta<TimeType>,
+        target_berthing_position: SpacePosition,
+        cost_per_waiting_time: Cost<CostType>,
+        cost_per_target_berthing_deviation: Cost<CostType>,
+    ) -> Self {
+        Vessel {
+            id,
+            length,
+            arrival_time,
+            processing_duration,
+            target_berthing_position,
+            cost_per_waiting_time,
+            cost_per_target_berthing_deviation,
+        }
+    }
+
+    /// Returns the unique identifier of the vessel.
+    ///
+    /// This function retrieves the `VesselId` associated with the vessel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.id(), VesselId::new(1));
+    /// ```
+    #[inline]
+    pub fn id(&self) -> VesselId {
+        self.id
+    }
+
+    /// Returns the length of the vessel.
+    ///
+    /// This function retrieves the `SpaceLength` of the vessel, which represents its size.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.length(), SpaceLength::new(100));
+    /// ```
+    #[inline]
+    pub fn length(&self) -> SpaceLength {
+        self.length
+    }
+
+    /// Returns the arrival time of the vessel.
+    ///
+    /// This function retrieves the `TimePoint` representing when the vessel arrives.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
+    /// ```
+    pub fn arrival_time(&self) -> TimePoint<TimeType> {
+        self.arrival_time
+    }
+
+    /// Returns the processing duration of the vessel.
+    ///
+    /// This function retrieves the `TimeDelta` representing how long it takes to process the vessel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
+    /// ```
+    pub fn processing_duration(&self) -> TimeDelta<TimeType> {
+        self.processing_duration
+    }
+
+    /// Returns the target berthing position of the vessel.
+    ///
+    /// This function retrieves the `SpacePosition` where the vessel is expected to berth.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
+    /// ```
+    pub fn target_berthing_position(&self) -> SpacePosition {
+        self.target_berthing_position
+    }
+
+    /// Returns the cost per waiting time for the vessel.
+    ///
+    /// This function retrieves the `Cost` associated with waiting time for the vessel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.cost_per_waiting_time().value(), 10);
+    /// ```
+    pub fn cost_per_waiting_time(&self) -> Cost<CostType> {
+        self.cost_per_waiting_time
+    }
+
+    /// Returns the cost per target berthing deviation for the vessel.
+    ///
+    /// This function retrieves the `Cost` associated with deviations from the target berthing position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// assert_eq!(vessel.cost_per_target_berthing_deviation().value(), 5);
+    /// ```
+    pub fn cost_per_target_berthing_deviation(&self) -> Cost<CostType> {
+        self.cost_per_target_berthing_deviation
+    }
+}
+
+impl<TimeType, CostType> Display for Vessel<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed + Display,
+    CostType: PrimInt + Signed + Display,
+{
+    /// Formats the `Vessel` for display.
+    ///
+    /// This implementation provides a string representation of the `Vessel`
+    /// including its identifier, length, arrival time, processing duration,
+    /// target berthing position, and cost parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::{Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(1622547800), // Example timestamp
+    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10), // Example cost per waiting time
+    ///     Cost::new(5), // Example cost per target berthing deviation
+    /// );
+    /// println!("{}", vessel);
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Vessel(id: {}, length: {}, arrival_time: {}, processing_duration: {}, target_berthing_position: {}, cost_per_waiting_time: {}, cost_per_target_berthing_deviation: {})",
+            self.id,
+            self.length,
+            self.arrival_time,
+            self.processing_duration,
+            self.target_berthing_position,
+            self.cost_per_waiting_time,
+            self.cost_per_target_berthing_deviation
+        )
+    }
+}
+
+/// Represents the Berthing Allocation Problem.
+///
+/// This struct encapsulates the problem's vessels and the quay length available for berthing.
+/// It provides methods to create a new problem instance, retrieve the quay length,
+/// and access the set of vessels involved in the problem.
+pub struct Problem<TimeType = i64, CostType = i64>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    vessels: HashSet<Vessel<TimeType, CostType>>,
+    quay_length: SpaceLength,
+}
+
+impl<TimeType, CostType> Problem<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    /// Creates a new `Problem` instance with the specified quay length.
+    ///
+    /// This function initializes a `Problem` with an empty set of vessels and the given quay length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use dock_alloc_model::{Problem, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessels = HashSet::new();
+    /// let quay_length = SpaceLength::new(1000);
+    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
+    /// ```
+    #[inline]
+    pub fn new(vessels: HashSet<Vessel<TimeType, CostType>>, quay_length: SpaceLength) -> Self {
+        Problem {
+            vessels,
+            quay_length,
+        }
+    }
+
+    /// Returns the quay length of the problem.
+    ///
+    /// This function retrieves the `SpaceLength` representing the length of the quay available for berthing vessels.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use dock_alloc_model::{Problem, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    ///
+    /// let vessels = HashSet::new();
+    /// let quay_length = SpaceLength::new(1000);
+    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
+    /// ```
+    #[inline]
+    pub fn quay_length(&self) -> SpaceLength {
+        self.quay_length
+    }
+
+    /// Returns a reference to the set of vessels in the problem.
+    ///
+    /// This function provides access to the `HashSet` of vessels, allowing iteration or inspection of the vessels involved in the problem.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use dock_alloc_model::{Problem, Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessels = HashSet::new();
+    /// let quay_length = SpaceLength::new(1000);
+    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// assert!(problem.vessels().is_empty());
+    /// ```
+    #[inline]
+    pub fn vessels(&self) -> &HashSet<Vessel<TimeType, CostType>> {
+        &self.vessels
+    }
+
+    /// Returns the number of vessels in the problem.
+    ///
+    /// This function returns the count of vessels currently stored in the problem's vessel set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use dock_alloc_model::{Problem, Vessel, VesselId};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    ///
+    /// let vessels = HashSet::new();
+    /// let quay_length = SpaceLength::new(1000);
+    /// let problem = Problem::<i64, i64>::new(vessels, quay_length);
+    /// assert_eq!(problem.vessel_len(), 0);
+    /// ```
+    #[inline]
+    pub fn vessel_len(&self) -> usize {
+        self.vessels.len()
+    }
+}
+
+/// Type alias for the Berthing Allocation Problem with default types for time and cost.
+///
+/// This alias simplifies the usage of the `Problem` struct by providing a default type for time and cost,
+/// which are both `i64`.
+pub type BerthAllocationProblem = Problem<i64, i64>;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +597,55 @@ mod tests {
     fn test_vessel_id_from_u64() {
         let id: VesselId = 42.into();
         assert_eq!(id.value(), 42);
+    }
+
+    #[test]
+    fn test_vessel_display() {
+        let vessel = Vessel::new(
+            VesselId::new(1),
+            SpaceLength::new(100),
+            TimePoint::new(1622547800),
+            TimeDelta::new(3600),
+            SpacePosition::new(50),
+            Cost::new(10),
+            Cost::new(5),
+        );
+        assert_eq!(
+            format!("{}", vessel),
+            "Vessel(id: VesselId(1), \
+            length: SpaceLength(100), \
+            arrival_time: TimePoint(1622547800), \
+            processing_duration: TimeDelta(3600), \
+            target_berthing_position: SpacePosition(50), \
+            cost_per_waiting_time: Cost(10), \
+            cost_per_target_berthing_deviation: Cost(5))"
+        );
+    }
+
+    #[test]
+    fn vessels_are_unique_by_id() {
+        let mut set = std::collections::HashSet::new();
+        let v1 = Vessel::new(
+            VesselId::new(1),
+            SpaceLength::new(100),
+            TimePoint::new(0),
+            TimeDelta::new(10),
+            SpacePosition::new(0),
+            Cost::new(1),
+            Cost::new(1),
+        );
+        let v2 = Vessel::new(
+            // same id, different fields
+            VesselId::new(1),
+            SpaceLength::new(200),
+            TimePoint::new(5),
+            TimeDelta::new(20),
+            SpacePosition::new(10),
+            Cost::new(2),
+            Cost::new(3),
+        );
+        set.insert(v1);
+        set.insert(v2);
+        assert_eq!(set.len(), 1);
     }
 }

--- a/crates/dock-alloc-model/src/lib.rs
+++ b/crates/dock-alloc-model/src/lib.rs
@@ -19,67 +19,54 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#[allow(dead_code)]
+#![allow(dead_code)]
+
+use dock_alloc_core::domain::{
+    Cost, SpaceInterval, SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint,
+};
+use num_traits::{PrimInt, Signed, Zero};
 use std::fmt::Display;
 use std::{
     cmp::Ordering,
     collections::{BTreeSet, HashMap, HashSet},
     fmt::Debug,
     hash::Hash,
-    iter,
 };
 
-use dock_alloc_core::domain::{
-    Cost, SpaceInterval, SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint,
-};
-use num_traits::{PrimInt, Signed};
-
-/// Represents a unique identifier for a vessel.
+/// A unique identifier for a berthing request.
 ///
-/// This identifier is used to track vessels in the system.
-/// It is a wrapper around a `u64` value, providing methods to create and access
-/// the identifier value.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::VesselId;
-///
-/// let vessel_id = VesselId::new(12345);
-/// assert_eq!(vessel_id.value(), 12345);
-/// ```
+/// This struct wraps a `u64` to provide type safety, ensuring that request IDs are not
+/// accidentally mixed with other numeric types throughout the API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct VesselId(u64);
+pub struct RequestId(u64);
 
-impl VesselId {
-    /// Creates a new `VesselId` with the given identifier value.
+impl RequestId {
+    /// Creates a new `RequestId`.
     ///
-    /// This function creates a new `VesselId` instance with the specified `u64` value.
+    /// This constructor takes a `u64` value and wraps it in the `RequestId` type.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::VesselId;
+    /// use dock_alloc_model::RequestId;
     ///
-    /// let id = VesselId::new(42);
-    /// assert_eq!(id.value(), 42);
+    /// let request_id = RequestId::new(42);
+    /// assert_eq!(request_id.value(), 42);
     /// ```
     #[inline]
     pub const fn new(id: u64) -> Self {
-        VesselId(id)
+        RequestId(id)
     }
 
-    /// Returns the underlying `u64` value of the `VesselId`.
-    ///
-    /// This function retrieves the `u64` value that the `VesselId` wraps.
+    /// Returns the underlying `u64` value of the ID.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::VesselId;
+    /// use dock_alloc_model::RequestId;
     ///
-    /// let id = VesselId::new(42);
-    /// assert_eq!(id.value(), 42);
+    /// let request_id = RequestId::new(123);
+    /// assert_eq!(request_id.value(), 123);
     /// ```
     #[inline]
     pub const fn value(&self) -> u64 {
@@ -87,647 +74,492 @@ impl VesselId {
     }
 }
 
-impl Display for VesselId {
-    /// Formats the `VesselId` for display.
+impl Display for RequestId {
+    /// Formats the `RequestId` for display.
     ///
-    /// This implementation provides a string representation of the `VesselId`
-    /// in the format `VesselId(value)`.
+    /// The format is `RequestId(value)`, which is useful for logging and debugging.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::VesselId;
+    /// use dock_alloc_model::RequestId;
     ///
-    /// let id = VesselId::new(42);
-    /// assert_eq!(format!("{}", id), "VesselId(42)");
+    /// let request_id = RequestId::new(101);
+    /// assert_eq!(format!("{}", request_id), "RequestId(101)");
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "VesselId({})", self.0)
+        write!(f, "RequestId({})", self.0)
     }
 }
 
-impl From<u64> for VesselId {
-    /// Converts a `u64` value into a `VesselId`.
+impl From<u64> for RequestId {
+    /// Converts a `u64` into a `RequestId`.
     ///
-    /// This implementation allows for easy conversion from a `u64` to a `VesselId`.
+    /// This allows for more ergonomic creation of `RequestId` instances from primitive integers.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::VesselId;
+    /// use dock_alloc_model::RequestId;
     ///
-    /// let id: VesselId = 42.into();
-    /// assert_eq!(id.value(), 42);
+    /// let id_from_u64: RequestId = 42.into();
+    /// assert_eq!(id_from_u64.value(), 42);
     /// ```
     fn from(value: u64) -> Self {
-        VesselId(value)
+        RequestId(value)
     }
 }
 
-/// Represents a vessel in the Berthing Allocation Problem.
+/// Represents a request for a berthing space at a quay.
 ///
-/// This struct encapsulates all the necessary information about a vessel,
-/// including its unique identifier, length, arrival time, processing duration,
-/// target berthing position, and associated costs.
+/// A `Request` encapsulates all constraints and cost parameters associated with a single
+/// request's berthing needs, such as its physical length, required processing time,
+/// target position, and feasible time/space windows.
 #[derive(Debug, Clone, Copy)]
-pub struct Vessel<TimeType = i64, CostType = i64>
+pub struct Request<TimeType = i64, CostType = i64>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    id: VesselId,
+    id: RequestId,
     length: SpaceLength,
-    arrival_time: TimePoint<TimeType>,
     processing_duration: TimeDelta<TimeType>,
-    target_berthing_position: SpacePosition,
-    cost_per_waiting_time: Cost<CostType>,
-    cost_per_target_berthing_deviation: Cost<CostType>,
+    target_position: SpacePosition,
+    cost_per_delay: Cost<CostType>,
+    cost_per_position_deviation: Cost<CostType>,
+    feasible_time_window: TimeInterval<TimeType>,
+    feasible_space_window: SpaceInterval,
+    drop_penalty: Option<Cost<CostType>>,
 }
 
-impl<TimeType, CostType> PartialEq for Vessel<TimeType, CostType>
+impl<TimeType, CostType> PartialEq for Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Compares two `Vessel` instances for equality based on their unique identifiers.
-    ///
-    /// This implementation checks if the `id` of one vessel is equal to the `id` of another vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// assert!(vessel1 == vessel2);
-    /// ```
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
 
-impl<TimeType, CostType> Eq for Vessel<TimeType, CostType>
+impl<TimeType, CostType> Eq for Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
 }
 
-impl<TimeType, CostType> Hash for Vessel<TimeType, CostType>
+impl<TimeType, CostType> Hash for Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Computes the hash of the `Vessel` based on its unique identifier.
-    ///
-    /// This implementation hashes the `id` of the vessel, allowing it to be used in hash-based collections.
-    ///
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::hash::{Hash, Hasher};
-    /// use std::collections::hash_map::DefaultHasher;
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// let mut h1 = DefaultHasher::new();
-    /// vessel1.hash(&mut h1);
-    /// let mut h2 = DefaultHasher::new();
-    /// vessel2.hash(&mut h2);
-    /// assert_eq!(h1.finish(), h2.finish());
-    /// ```
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
     }
 }
 
-impl<TimeType, CostType> PartialOrd for Vessel<TimeType, CostType>
+impl<TimeType, CostType> PartialOrd for Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Compares two `Vessel` instances for ordering based on their unique identifiers.
-    ///
-    /// This implementation allows for partial ordering of vessels, primarily based on their `id`.
-    ///
-    /// # Note
-    ///
-    /// You might expect ordering based on the arrival time or other attributes,
-    /// but this implementation only considers the `id` for simplicity. You need
-    /// to implement additional logic if you want to compare vessels based on other attributes.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(2),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// assert!(vessel1 < vessel2);
-    /// ```
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<TimeType, CostType> Ord for Vessel<TimeType, CostType>
+impl<TimeType, CostType> Ord for Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Compares two `Vessel` instances for total ordering based on their unique identifiers.
-    ///
-    /// This implementation allows for total ordering of vessels, primarily based on their `id`.
-    ///
-    /// # Note
-    ///
-    /// You might expect ordering based on the arrival time or other attributes,
-    /// but this implementation only considers the `id` for simplicity. You need
-    /// to implement additional logic if you want to compare vessels based on other attributes.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(2),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// assert!(vessel1 < vessel2);
-    /// ```
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.id.cmp(&other.id)
     }
 }
 
-impl<TimeType, CostType> Vessel<TimeType, CostType>
+/// An error indicating a request's feasible time window is too short.
+///
+/// This error occurs during `Request` creation if the duration of the `feasible_time_window`
+/// is less than the required `processing_duration`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RequestTimeWindowTooShortError<TimeType: PrimInt + Signed> {
+    feasible_time_window: TimeInterval<TimeType>,
+    processing_duration: TimeDelta<TimeType>,
+}
+
+impl<TimeType: PrimInt + Signed> RequestTimeWindowTooShortError<TimeType> {
+    /// Creates a new `RequestTimeWindowTooShortError`.
+    pub fn new(
+        feasible_time_window: TimeInterval<TimeType>,
+        processing_duration: TimeDelta<TimeType>,
+    ) -> Self {
+        Self {
+            feasible_time_window,
+            processing_duration,
+        }
+    }
+
+    /// Returns the feasible time window that was too short.
+    pub fn feasible_time_window(&self) -> TimeInterval<TimeType> {
+        self.feasible_time_window
+    }
+
+    /// Returns the processing duration that did not fit.
+    pub fn processing_duration(&self) -> TimeDelta<TimeType> {
+        self.processing_duration
+    }
+}
+impl<TimeType: PrimInt + Signed + Display> Display for RequestTimeWindowTooShortError<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Request time window too short: feasible_time_window = {}, processing_duration = {}",
+            self.feasible_time_window, self.processing_duration
+        )
+    }
+}
+
+/// An error indicating a request's feasible space window is too short.
+///
+/// This error occurs during `Request` creation if the length of the `feasible_space_window`
+/// is less than the required `length` of the request.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RequestSpaceWindowTooShortError {
+    feasible_space_window: SpaceInterval,
+    length: SpaceLength,
+}
+
+impl RequestSpaceWindowTooShortError {
+    /// Creates a new `RequestSpaceWindowTooShortError`.
+    pub fn new(feasible_space_window: SpaceInterval, length: SpaceLength) -> Self {
+        Self {
+            feasible_space_window,
+            length,
+        }
+    }
+
+    /// Returns the feasible space window that was too short.
+    pub fn feasible_space_window(&self) -> SpaceInterval {
+        self.feasible_space_window
+    }
+
+    /// Returns the request length that did not fit.
+    pub fn length(&self) -> SpaceLength {
+        self.length
+    }
+}
+impl Display for RequestSpaceWindowTooShortError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Request space window too short: feasible_space_window = {}, length = {}",
+            self.feasible_space_window, self.length
+        )
+    }
+}
+
+/// An error that can occur during the creation of a `Request`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RequestCreationError<TimeType: PrimInt + Signed> {
+    /// The feasible time window is shorter than the processing duration.
+    TimeWindowTooShort(RequestTimeWindowTooShortError<TimeType>),
+    /// The feasible space window is shorter than the request's length.
+    SpaceWindowTooShort(RequestSpaceWindowTooShortError),
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for RequestCreationError<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TimeWindowTooShort(e) => write!(f, "{}", e),
+            Self::SpaceWindowTooShort(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error
+    for RequestCreationError<TimeType>
+{
+}
+
+impl<TimeType, CostType> Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Creates a new `Vessel` instance with the specified parameters.
+    /// Creates a new `Request` after validating its parameters.
     ///
-    /// This function initializes a `Vessel` with its unique identifier, length,
-    /// arrival time, processing duration, target berthing position, and cost parameters.
+    /// This function constructs a `Request` from its constituent parts. It performs
+    /// critical validation to ensure the request is logically consistent before creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the request parameters are invalid:
+    /// - `RequestCreationError::TimeWindowTooShort`: If the `feasible_time_window`'s
+    ///   duration is less than the `processing_duration`.
+    /// - `RequestCreationError::SpaceWindowTooShort`: If the `feasible_space_window`'s
+    ///   length is less than the request's `length`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    /// use dock_alloc_core::domain::{SpaceLength, TimeDelta, SpacePosition, Cost, TimeInterval, TimePoint, SpaceInterval};
+    /// use dock_alloc_model::{Request, RequestId};
     ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
+    /// let request = Request::<i64, i64>::new(
+    ///     RequestId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(0), TimePoint::new(7200)),
+    ///     SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(200)),
+    ///     Some(Cost::new(1000)),
     /// );
-    /// assert_eq!(vessel.id(), VesselId::new(1));
-    /// assert_eq!(vessel.length(), SpaceLength::new(100));
-    /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
-    /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
-    /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
-    /// assert_eq!(vessel.cost_per_waiting_time(), Cost::new(10));
-    /// assert_eq!(vessel.cost_per_target_berthing_deviation(), Cost::new(5));
+    ///
+    /// assert!(request.is_ok());
+    ///
+    /// // Example of a time window that is too short
+    /// let bad_request = Request::<i64, i64>::new(
+    ///     RequestId::new(2),
+    ///     SpaceLength::new(100),
+    ///     TimeDelta::new(3600),
+    ///     SpacePosition::new(50),
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(0), TimePoint::new(3000)), // Duration < 3600
+    ///     SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(200)),
+    ///     None,
+    /// );
+    ///
+    /// assert!(bad_request.is_err());
     /// ```
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     pub fn new(
-        id: VesselId,
+        id: RequestId,
         length: SpaceLength,
-        arrival_time: TimePoint<TimeType>,
         processing_duration: TimeDelta<TimeType>,
-        target_berthing_position: SpacePosition,
-        cost_per_waiting_time: Cost<CostType>,
-        cost_per_target_berthing_deviation: Cost<CostType>,
-    ) -> Self {
-        Vessel {
+        target_position: SpacePosition,
+        cost_per_delay: Cost<CostType>,
+        cost_per_position_deviation: Cost<CostType>,
+        feasible_time_window: TimeInterval<TimeType>,
+        feasible_space_window: SpaceInterval,
+        drop_penalty: Option<Cost<CostType>>,
+    ) -> Result<Self, RequestCreationError<TimeType>> {
+        if feasible_time_window.duration() < processing_duration {
+            return Err(RequestCreationError::TimeWindowTooShort(
+                RequestTimeWindowTooShortError::new(feasible_time_window, processing_duration),
+            ));
+        }
+        if feasible_space_window.start() + length > feasible_space_window.end() {
+            return Err(RequestCreationError::SpaceWindowTooShort(
+                RequestSpaceWindowTooShortError::new(feasible_space_window, length),
+            ));
+        }
+
+        Ok(Request {
             id,
             length,
-            arrival_time,
             processing_duration,
-            target_berthing_position,
-            cost_per_waiting_time,
-            cost_per_target_berthing_deviation,
-        }
+            target_position,
+            cost_per_delay,
+            cost_per_position_deviation,
+            feasible_time_window,
+            feasible_space_window,
+            drop_penalty,
+        })
     }
 
-    /// Returns the unique identifier of the vessel.
-    ///
-    /// This function retrieves the `VesselId` associated with the vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.id(), VesselId::new(1));
-    /// ```
+    /// Returns the unique identifier of the request.
     #[inline]
-    pub fn id(&self) -> VesselId {
+    pub fn id(&self) -> RequestId {
         self.id
     }
 
-    /// Returns the length of the vessel.
-    ///
-    /// This function retrieves the `SpaceLength` of the vessel, which represents its size.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.length(), SpaceLength::new(100));
-    /// ```
+    /// Returns the physical length of the request for this request.
     #[inline]
     pub fn length(&self) -> SpaceLength {
         self.length
     }
 
-    /// Returns the arrival time of the vessel.
+    /// Returns the earliest time the request can arrive.
     ///
-    /// This function retrieves the `TimePoint` representing when the vessel arrives.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
-    /// ```
+    /// This is defined as the start of the `feasible_time_window`.
     #[inline]
     pub fn arrival_time(&self) -> TimePoint<TimeType> {
-        self.arrival_time
+        self.feasible_time_window.start()
     }
 
-    /// Returns the processing duration of the vessel.
-    ///
-    /// This function retrieves the `TimeDelta` representing how long it takes to process the vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
-    /// ```
+    /// Returns the required time for processing (berthing duration).
     #[inline]
     pub fn processing_duration(&self) -> TimeDelta<TimeType> {
         self.processing_duration
     }
 
-    /// Returns the target berthing position of the vessel.
-    ///
-    /// This function retrieves the `SpacePosition` where the vessel is expected to berth.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
-    /// ```
+    /// Returns the preferred berthing position for the request.
     #[inline]
-    pub fn target_berthing_position(&self) -> SpacePosition {
-        self.target_berthing_position
+    pub fn target_position(&self) -> SpacePosition {
+        self.target_position
     }
 
-    /// Returns the cost per waiting time for the vessel.
-    ///
-    /// This function retrieves the `Cost` associated with waiting time for the vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.cost_per_waiting_time().value(), 10);
-    /// ```
+    /// Returns the cost incurred for each unit of time the request waits after arrival.
     #[inline]
-    pub fn cost_per_waiting_time(&self) -> Cost<CostType> {
-        self.cost_per_waiting_time
+    pub fn cost_per_delay(&self) -> Cost<CostType> {
+        self.cost_per_delay
     }
 
-    /// Returns the cost per target berthing deviation for the vessel.
-    ///
-    /// This function retrieves the `Cost` associated with deviations from the target berthing position.
+    /// Returns the cost incurred for each unit of distance from the target position.
+    #[inline]
+    pub fn cost_per_position_deviation(&self) -> Cost<CostType> {
+        self.cost_per_position_deviation
+    }
+
+    /// Returns the time interval within which the request must be processed.
+    #[inline]
+    pub fn feasible_time_window(&self) -> TimeInterval<TimeType> {
+        self.feasible_time_window
+    }
+
+    /// Returns the space interval along the quay where the request can be berthed.
+    #[inline]
+    pub fn feasible_space_window(&self) -> SpaceInterval {
+        self.feasible_space_window
+    }
+
+    /// Returns the penalty cost if this request is not assigned (dropped), if applicable.
+    #[inline]
+    pub fn drop_penalty(&self) -> Option<Cost<CostType>> {
+        self.drop_penalty
+    }
+
+    /// Returns `true` if the request can be dropped (i.e., has a drop penalty).
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{SpaceLength, TimeDelta, SpacePosition, Cost, TimeInterval, TimePoint, SpaceInterval};
+    /// use dock_alloc_model::{Request, RequestId};
     ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// assert_eq!(vessel.cost_per_target_berthing_deviation().value(), 5);
+    /// let droppable_request = Request::<i64, i64>::new(RequestId::new(1), SpaceLength::new(100), TimeDelta::new(10), SpacePosition::new(0), Cost::new(1), Cost::new(1), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(200)), Some(Cost::new(1000))).unwrap();
+    /// let mandatory_request = Request::<i64, i64>::new(RequestId::new(2), SpaceLength::new(100), TimeDelta::new(10), SpacePosition::new(0), Cost::new(1), Cost::new(1), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(200)), None).unwrap();
+    ///
+    /// assert!(droppable_request.is_droppable());
+    /// assert!(!mandatory_request.is_droppable());
     /// ```
     #[inline]
-    pub fn cost_per_target_berthing_deviation(&self) -> Cost<CostType> {
-        self.cost_per_target_berthing_deviation
+    pub fn is_droppable(&self) -> bool {
+        self.drop_penalty.is_some()
     }
 }
 
-impl<TimeType, CostType> Vessel<TimeType, CostType>
+impl<TimeType, CostType> Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed + TryFrom<TimeType>,
 {
-    /// Calculates the cost incurred by the vessel for waiting time.
+    /// Calculates the total cost for a given waiting time.
     ///
-    /// This function computes the cost based on the waiting time provided as a `TimeDelta`.
-    /// It multiplies the waiting time by the cost per waiting time to determine the total cost.
+    /// The cost is calculated as `waiting_time` * `cost_per_delay`.
     ///
     /// # Panics
     ///
-    /// This function will panic if the waiting time does not fit into the `CostType` and a conversion
-    /// would result in an overflow or underflow.
+    /// Panics if the numeric value of `waiting_time` cannot be converted into `CostType`.
+    /// This may happen if `TimeType` is a larger integer type than `CostType`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    /// use dock_alloc_core::domain::{SpaceLength, TimeDelta, SpacePosition, Cost, TimeInterval, TimePoint, SpaceInterval};
+    /// use dock_alloc_model::{Request, RequestId};
     ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let waiting_time = TimeDelta::new(2); // Example waiting time in seconds
-    /// let cost = vessel.waiting_cost(waiting_time);
-    /// assert_eq!(cost.value(), 20); // 10 * 2
+    /// let request = Request::<i64, i64>::new(RequestId::new(1), SpaceLength::new(100), TimeDelta::new(3600), SpacePosition::new(50), Cost::new(10), Cost::new(5), TimeInterval::new(TimePoint::new(0), TimePoint::new(7200)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(200)), None).unwrap();
+    /// let waiting_time = TimeDelta::new(15); // 15 time units of waiting
+    ///
+    /// // Cost = 15 * 10 = 150
+    /// assert_eq!(request.waiting_cost(waiting_time), Cost::new(150));
     /// ```
     #[inline]
     pub fn waiting_cost(&self, waiting_time: TimeDelta<TimeType>) -> Cost<CostType> {
         let scalar: CostType = CostType::try_from(waiting_time.value())
             .ok()
             .expect("waiting time does not fit in CostType");
-        self.cost_per_waiting_time * scalar
+        self.cost_per_delay * scalar
     }
 }
 
-impl<TimeType, CostType> Vessel<TimeType, CostType>
+impl<TimeType, CostType> Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed + TryFrom<usize>,
 {
-    /// Calculates the cost incurred by the vessel for deviations from the target berthing position.
+    /// Calculates the total cost for a given deviation from the target position.
     ///
-    /// This function computes the cost based on the deviation from the target berthing position
-    /// provided as a `SpaceLength`. It multiplies the deviation by the cost per target berthing deviation
-    /// to determine the total cost.
+    /// The cost is calculated as `deviation` * `cost_per_position_deviation`.
     ///
     /// # Panics
     ///
-    /// This function will panic if the deviation does not fit into the `CostType` and a conversion
-    /// would result in an overflow or underflow.
+    /// Panics if the numeric value of the `deviation` `SpaceLength` cannot be
+    /// converted into `CostType`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    /// use dock_alloc_core::domain::{SpaceLength, TimeDelta, SpacePosition, Cost, TimeInterval, TimePoint, SpaceInterval};
+    /// use dock_alloc_model::{Request, RequestId};
     ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let deviation = SpaceLength::new(3); // Example deviation in length
-    /// let cost = vessel.target_berthing_deviation_cost(deviation);
-    /// assert_eq!(cost.value(), 15); // 5 * 3
+    /// let request = Request::<i64, i64>::new(RequestId::new(1), SpaceLength::new(100), TimeDelta::new(3600), SpacePosition::new(50), Cost::new(10), Cost::new(5), TimeInterval::new(TimePoint::new(0), TimePoint::new(7200)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(200)), None).unwrap();
+    /// let deviation = SpaceLength::new(20); // 20 units of distance from target
+    ///
+    /// // Cost = 20 * 5 = 100
+    /// assert_eq!(request.target_position_deviation_cost(deviation), Cost::new(100));
     /// ```
     #[inline]
-    pub fn target_berthing_deviation_cost(&self, deviation: SpaceLength) -> Cost<CostType> {
+    pub fn target_position_deviation_cost(&self, deviation: SpaceLength) -> Cost<CostType> {
         let scalar: CostType = CostType::try_from(deviation.value())
             .ok()
             .expect("deviation does not fit in CostType");
-        self.cost_per_target_berthing_deviation * scalar
+        self.cost_per_position_deviation * scalar
     }
 }
 
-impl<TimeType, CostType> Display for Vessel<TimeType, CostType>
+impl<TimeType, CostType> Display for Request<TimeType, CostType>
 where
     TimeType: PrimInt + Signed + Display,
     CostType: PrimInt + Signed + Display,
 {
-    /// Formats the `Vessel` for display.
-    ///
-    /// This implementation provides a string representation of the `Vessel`
-    /// including its identifier, length, arrival time, processing duration,
-    /// target berthing position, and cost parameters.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// println!("{}", vessel);
-    /// ```
+    /// Formats the `Request` for display.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Vessel(id: {}, length: {}, arrival_time: {}, processing_duration: {}, target_berthing_position: {}, cost_per_waiting_time: {}, cost_per_target_berthing_deviation: {})",
+            "Request(id: {}, length: {}, arrival_time: {}, processing_duration: {}, target_position: {}, cost_per_delay: {}, cost_per_position_deviation: {})",
             self.id,
             self.length,
-            self.arrival_time,
+            self.arrival_time(),
             self.processing_duration,
-            self.target_berthing_position,
-            self.cost_per_waiting_time,
-            self.cost_per_target_berthing_deviation
+            self.target_position,
+            self.cost_per_delay,
+            self.cost_per_position_deviation
         )
     }
 }
 
-/// Represents an assignment of a vessel to a berthing position and time.
+/// Represents a concrete assignment of a request to a time and place.
 ///
-/// This struct encapsulates the details of a vessel's assignment, including the vessel itself,
-/// the berthing position along the quay, and the berthing time.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{Assignment, VesselId};
-/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-///
-/// let assignment = Assignment::new(
-///     VesselId::new(1),
-///     SpacePosition::new(100),
-///     TimePoint::new(1622547800)
-/// );
-/// assert_eq!(assignment.vessel_id(), VesselId::new(1));
-/// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
-/// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
-/// ```
+/// An `Assignment` links a `RequestId` to a specific `berthing_time` and `berthing_position`,
+/// representing a fixed allocation on the quay.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Assignment<TimeType = i64>
 where
     TimeType: PrimInt + Signed,
 {
-    vessel_id: VesselId,
+    request_id: RequestId,
     berthing_position: SpacePosition,
     berthing_time: TimePoint<TimeType>,
 }
@@ -736,175 +568,81 @@ impl<TimeType> Assignment<TimeType>
 where
     TimeType: PrimInt + Signed,
 {
-    /// Creates a new `Assignment` instance with the specified parameters.
-    ///
-    /// This function initializes an `Assignment` with the vessel's unique identifier,
-    /// the berthing position along the quay, and the berthing time.
+    /// Creates a new `Assignment`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
     /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    /// use dock_alloc_model::{Assignment, RequestId};
     ///
     /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
+    ///     RequestId::new(1),
     ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
+    ///     TimePoint::new(1622547800i64)
     /// );
-    /// assert_eq!(assignment.vessel_id(), VesselId::new(1));
-    /// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
-    /// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+    ///
+    /// assert_eq!(assignment.request_id().value(), 1);
+    /// assert_eq!(assignment.berthing_position().value(), 100);
     /// ```
     #[inline]
     pub fn new(
-        vessel_id: VesselId,
+        request_id: RequestId,
         berthing_position: SpacePosition,
         berthing_time: TimePoint<TimeType>,
     ) -> Self {
-        Assignment {
-            vessel_id,
+        Self {
+            request_id,
             berthing_position,
             berthing_time,
         }
     }
 
-    /// Returns the unique identifier of the vessel associated with the assignment.
-    ///
-    /// This function retrieves the `VesselId` of the vessel that has
-    /// been assigned to a specific berthing position and time.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// assert_eq!(assignment.vessel_id(), VesselId::new(1));
-    /// ```
+    /// Returns the ID of the request being assigned.
     #[inline]
-    pub fn vessel_id(&self) -> VesselId {
-        self.vessel_id
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
     }
 
-    /// Returns the berthing position of the vessel.
-    ///
-    /// This function retrieves the `SpacePosition` along the
-    /// quay where the vessel is assigned to berth.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
-    /// ```
+    /// Returns the assigned starting position on the quay.
     #[inline]
     pub fn berthing_position(&self) -> SpacePosition {
         self.berthing_position
     }
 
-    /// Returns the berthing time of the vessel.
-    ///
-    /// This function retrieves the `TimePoint` representing
-    /// when the vessel is scheduled to berth.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
-    /// ```
+    /// Returns the assigned start time for berthing.
     #[inline]
     pub fn berthing_time(&self) -> TimePoint<TimeType> {
         self.berthing_time
     }
 }
-
 impl<TimeType> Display for Assignment<TimeType>
 where
     TimeType: PrimInt + Signed + Display,
 {
     /// Formats the `Assignment` for display.
-    ///
-    /// This implementation provides a string representation of the `Assignment`
-    /// including the vessel identifier, berthing position, and berthing time.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// println!("{}", assignment);
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Assignment(vessel_id: {}, berthing_position: {}, berthing_time: {})",
-            self.vessel_id, self.berthing_position, self.berthing_time
+            "Assignment(request_id: {}, berthing_position: {}, berthing_time: {})",
+            self.request_id, self.berthing_position, self.berthing_time
         )
     }
 }
 
-/// Represents an entry in the Berthing Allocation Problem.
+/// Represents the status of a request within a `Problem` definition.
 ///
-/// This enum distinguishes between vessels that are unassigned and those
-/// that have been pre-assigned specific berthing positions and times.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{ProblemEntry, Assignment, VesselId};
-/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-///
-/// let unassigned: ProblemEntry<i64> = ProblemEntry::Unassigned(VesselId::new(1));
-/// let pre_assigned: ProblemEntry<i64> = ProblemEntry::PreAssigned(Assignment::new(
-///     VesselId::new(2),
-///     SpacePosition::new(100),
-///     TimePoint::new(1622547800)
-/// ));
-/// assert!(matches!(unassigned, ProblemEntry::Unassigned(_)));
-/// assert!(matches!(pre_assigned, ProblemEntry::PreAssigned(_)));
-/// ```
+/// A request can either be `Unassigned`, meaning a solver is free to find an
+/// assignment for it, or `PreAssigned`, meaning it has a fixed assignment
+/// that the solver must respect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ProblemEntry<TimeType = i64>
 where
     TimeType: PrimInt + Signed,
 {
-    /// A vessel that has not been assigned a berthing position or time.
-    ///
-    /// This variant holds the `VesselId` of the unassigned vessel.
-    /// The solver can decide freely where and when to berth this vessel.
-    Unassigned(VesselId),
-
-    /// A vessel that has been pre-assigned a specific berthing position and time.
-    ///
-    /// This variant holds an `Assignment` struct containing the details of the pre-assignment.
-    /// The solver must respect this assignment and cannot change it.
+    /// The request needs to be scheduled by a solver.
+    Unassigned(RequestId),
+    /// The request has a fixed, mandatory assignment.
     PreAssigned(Assignment<TimeType>),
 }
 
@@ -913,331 +651,110 @@ where
     TimeType: PrimInt + Signed + Display,
 {
     /// Formats the `ProblemEntry` for display.
-    ///
-    /// This implementation provides a string representation of the `ProblemEntry`
-    /// indicating whether it is an unassigned vessel or a pre-assigned vessel with its details.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{ProblemEntry, Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let unassigned: ProblemEntry<i64> = ProblemEntry::Unassigned(VesselId::new(1));
-    /// let pre_assigned: ProblemEntry<i64> = ProblemEntry::PreAssigned(Assignment::new(
-    ///     VesselId::new(2),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// ));
-    /// println!("{}", unassigned);
-    /// println!("{}", pre_assigned);
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProblemEntry::Unassigned(vessel_id) => {
-                write!(f, "Unassigned(vessel_id: {})", vessel_id)
+            ProblemEntry::Unassigned(request_id) => {
+                write!(f, "Unassigned(request_id: {})", request_id)
             }
-            ProblemEntry::PreAssigned(assignment) => {
-                write!(f, "PreAssigned({})", assignment)
-            }
+            ProblemEntry::PreAssigned(assignment) => write!(f, "PreAssigned({})", assignment),
         }
     }
 }
 
-/// Error indicating that a vessel with a specified ID is missing.
-///
-/// This error is used to signal that a required vessel could not be found
-/// in the context of a berthing allocation problem.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::MissingVesselError;
-///
-/// let error = MissingVesselError::new(1.into());
-/// assert_eq!(error.vessel_id(), 1.into());
-/// ```
+/// An error indicating that a `ProblemEntry` refers to a non-existent `RequestId`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct MissingVesselError(VesselId);
-
-impl Display for MissingVesselError {
-    /// Formats the `MissingVesselError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the ID of the missing vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error = MissingVesselError::new(VesselId::new(1).into());
-    /// println!("{}", error);
-    /// ```
+pub struct MissingRequestError(RequestId);
+impl Display for MissingRequestError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Missing vessel with ID: {}", self.0)
+        write!(f, "Missing request with ID: {}", self.0)
     }
 }
 
-impl std::error::Error for MissingVesselError {}
+impl std::error::Error for MissingRequestError {}
 
-impl From<VesselId> for MissingVesselError {
-    /// Converts a `VesselId` into a `MissingVesselError`.
-    ///
-    /// This implementation allows for easy creation of a `MissingVesselError`
-    /// from a `VesselId`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error: MissingVesselError = VesselId::new(1).into();
-    /// assert_eq!(error.vessel_id(), 1.into());
-    /// ```
+impl From<RequestId> for MissingRequestError {
     #[inline]
-    fn from(vessel_id: VesselId) -> Self {
-        MissingVesselError(vessel_id)
+    fn from(request_id: RequestId) -> Self {
+        MissingRequestError(request_id)
     }
 }
 
-impl MissingVesselError {
-    /// Creates a new `MissingVesselError` with the specified vessel ID.
-    ///
-    /// This function initializes a `MissingVesselError` with the given `VesselId`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error = MissingVesselError::new(VesselId::new(1));
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// ```
+impl MissingRequestError {
+    /// Creates a new `MissingRequestError`.
     #[inline]
-    pub fn new(vessel_id: VesselId) -> Self {
-        MissingVesselError(vessel_id)
+    pub fn new(request_id: RequestId) -> Self {
+        MissingRequestError(request_id)
     }
 
-    /// Returns the unique identifier of the missing vessel.
-    ///
-    /// This function retrieves the `VesselId` associated with the missing vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error = MissingVesselError::new(VesselId::new(1));
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// ```
+    /// Returns the ID of the request that was missing.
     #[inline]
-    pub fn vessel_id(&self) -> VesselId {
+    pub fn request_id(&self) -> RequestId {
         self.0
     }
 }
 
-/// Error indicating that a vessel is out of placed in a way that exceeds the quay length.
-///
-/// This error is used to signal that a vessel's end position exceeds the quay length.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-/// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-///
-/// let error = VesselOutOfBoundsError::new(
-///     VesselId::new(1),
-///     SpacePosition::new(1500),
-///     SpaceLength::new(1000)
-/// );
-/// assert_eq!(error.vessel_id(), VesselId::new(1));
-/// assert_eq!(error.end_pos(), SpacePosition::new(1500));
-/// assert_eq!(error.quay_length(), SpaceLength::new(1000));
-/// ```
+/// An error indicating that a pre-assignment places a request outside the quay's boundaries.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct VesselOutOfBoundsError {
-    vessel_id: VesselId,
+pub struct RequestOutOfBoundsError {
+    request_id: RequestId,
     end_pos: SpacePosition,
     quay_length: SpaceLength,
 }
 
-impl Display for VesselOutOfBoundsError {
-    /// Formats the `VesselOutOfBoundsError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the vessel ID, end position, and quay length.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// println!("{}", error);
-    /// ```
+impl Display for RequestOutOfBoundsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Vessel with ID {} is out of bounds: end position {} exceeds quay length {}",
-            self.vessel_id, self.end_pos, self.quay_length
+            "Request with ID {} is out of bounds: end position {} exceeds quay length {}",
+            self.request_id, self.end_pos, self.quay_length
         )
     }
 }
 
-impl std::error::Error for VesselOutOfBoundsError {}
+impl std::error::Error for RequestOutOfBoundsError {}
 
-impl VesselOutOfBoundsError {
-    /// Creates a new `VesselOutOfBoundsError` with the specified parameters.
-    ///
-    /// This function initializes a `VesselOutOfBoundsError` with the vessel's unique identifier,
-    /// the end position, and the quay length.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// assert_eq!(error.end_pos(), SpacePosition::new(1500));
-    /// assert_eq!(error.quay_length(), SpaceLength::new(1000));
-    /// ```
+impl RequestOutOfBoundsError {
+    /// Creates a new `RequestOutOfBoundsError`.
     #[inline]
-    pub fn new(vessel_id: VesselId, end_pos: SpacePosition, quay_length: SpaceLength) -> Self {
-        VesselOutOfBoundsError {
-            vessel_id,
+    pub fn new(request_id: RequestId, end_pos: SpacePosition, quay_length: SpaceLength) -> Self {
+        Self {
+            request_id,
             end_pos,
             quay_length,
         }
     }
 
-    /// Returns the unique identifier of the vessel associated with the error.
-    ///
-    /// This function retrieves the `VesselId` of the vessel that is out of bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// ```
-    pub fn vessel_id(&self) -> VesselId {
-        self.vessel_id
+    /// Returns the ID of the out-of-bounds request.
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
     }
 
-    /// Returns the end position of the vessel that caused the error.
-    ///
-    /// This function retrieves the `SpacePosition` representing the end position of the vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.end_pos(), SpacePosition::new(1500));
-    /// ```
+    /// Returns the calculated end position that was out of bounds.
     pub fn end_pos(&self) -> SpacePosition {
         self.end_pos
     }
 
-    /// Returns the quay length associated with the error.
-    ///
-    /// This function retrieves the `SpaceLength` representing the quay length.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.quay_length(), SpaceLength::new(1000));
-    /// ```
+    /// Returns the total length of the quay.
     pub fn quay_length(&self) -> SpaceLength {
         self.quay_length
     }
 }
 
-/// Represents a rectangular region in the time-space domain for a vessel.
+/// A rectangle representing an assigned request in time and space.
 ///
-/// This struct encapsulates the vessel's identifier, the time interval during which
-/// the vessel occupies a position, and the spatial interval along the quay that the vessel occupies.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{VesselRect, VesselId};
-/// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-///
-/// let vessel_rect = VesselRect::new(
-///     VesselId::new(1),
-///     TimeInterval::new(0.into(), 10.into()),
-///     SpaceInterval::new(100.into(), 200.into())
-/// );
-/// assert_eq!(vessel_rect.id(), VesselId::new(1));
-/// assert_eq!(vessel_rect.time_interval(), &TimeInterval::new(0.into(), 10.into()));
-/// assert_eq!(vessel_rect.space_interval(), &SpaceInterval::new(100.into(), 200.into()));
-/// ```
+/// This is a utility struct used for overlap detection, representing the time-space
+/// area occupied by an assigned request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct VesselRect<TimeType: PrimInt + Signed> {
-    id: VesselId,
+pub struct RequestRect<TimeType: PrimInt + Signed> {
+    id: RequestId,
     time_interval: TimeInterval<TimeType>,
     space_interval: SpaceInterval,
 }
 
-impl<TimeType: PrimInt + Signed> VesselRect<TimeType> {
-    /// Creates a new `VesselRect` instance with the specified parameters.
-    ///
-    /// This function initializes a `VesselRect` with the vessel's unique identifier,
-    /// the time interval during which the vessel occupies a position,
-    /// and the spatial interval along the quay that the vessel occupies.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// assert_eq!(vessel_rect.id(), VesselId::new(1));
-    /// assert_eq!(vessel_rect.time_interval(), &TimeInterval::new(0.into(), 10.into()));
-    /// assert_eq!(vessel_rect.space_interval(), &SpaceInterval::new(100.into(), 200.into()));
-    /// ```
+impl<TimeType: PrimInt + Signed> RequestRect<TimeType> {
+    /// Creates a new `RequestRect`.
     pub fn new(
-        id: VesselId,
+        id: RequestId,
         time_interval: TimeInterval<TimeType>,
         space_interval: SpaceInterval,
     ) -> Self {
@@ -1248,311 +765,249 @@ impl<TimeType: PrimInt + Signed> VesselRect<TimeType> {
         }
     }
 
-    /// Returns the unique identifier of the vessel associated with the rectangle.
-    ///
-    /// This function retrieves the `VesselId` of the vessel that the rectangle represents.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// assert_eq!(vessel_rect.id(), VesselId::new(1));
-    /// ```
+    /// Returns the ID of the request associated with this rectangle.
     #[inline]
-    pub fn id(&self) -> VesselId {
+    pub fn id(&self) -> RequestId {
         self.id
     }
 
-    /// Returns the time interval during which the vessel occupies a position.
-    ///
-    /// This function retrieves a reference to the `TimeInterval` representing
-    /// the time span of the vessel's occupation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// assert_eq!(vessel_rect.time_interval(), &TimeInterval::new(0.into(), 10.into()));
-    /// ```
+    /// Returns the time interval occupied by the request.
     pub fn time_interval(&self) -> &TimeInterval<TimeType> {
         &self.time_interval
     }
 
-    /// Returns the spatial interval along the quay that the vessel occupies.
-    ///
-    /// This function retrieves a reference to the `SpaceInterval` representing
-    /// the spatial span of the vessel's occupation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// assert_eq!(vessel_rect.space_interval(), &SpaceInterval::new(100.into(), 200.into()));
-    /// ```
+    /// Returns the space interval occupied by the request.
     pub fn space_interval(&self) -> &SpaceInterval {
         &self.space_interval
     }
 }
 
-impl<TimeType: PrimInt + Signed + Display> Display for VesselRect<TimeType> {
-    /// Formats the `VesselRect` for display.
-    ///
-    /// This implementation provides a string representation of the `VesselRect`
-    /// including the vessel identifier, time interval, and space interval.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// println!("{}", vessel_rect);
-    /// ```
+impl<TimeType: PrimInt + Signed + Display> Display for RequestRect<TimeType> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "VesselRect(id: {}, time_interval: {}, space_interval: {})",
+            "RequestRect(id: {}, time_interval: {}, space_interval: {})",
             self.id, self.time_interval, self.space_interval
         )
     }
 }
 
-/// Error indicating that two vessels overlap in their assigned time-space regions.
-///
-/// This error is used to signal that two vessels have been assigned overlapping
-/// time intervals and spatial intervals, which is not allowed in the berthing allocation problem.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-/// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-///
-/// let vessel_rect_1 = VesselRect::new(
-///     VesselId::new(1),
-///     TimeInterval::new(0.into(), 10.into()),
-///     SpaceInterval::new(100.into(), 200.into())
-/// );
-///
-/// let vessel_rect_2 = VesselRect::new(
-///     VesselId::new(2),
-///     TimeInterval::new(5.into(), 15.into()),
-///     SpaceInterval::new(150.into(), 250.into())
-/// );
-/// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-/// assert_eq!(error.a(), &vessel_rect_1);
-/// assert_eq!(error.b(), &vessel_rect_2);
-/// ```
+/// An error indicating that two assigned requests overlap in both time and space.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct VesselOverlapError<TimeType: PrimInt + Signed> {
-    a: VesselRect<TimeType>,
-    b: VesselRect<TimeType>,
+pub struct RequestOverlapError<TimeType: PrimInt + Signed> {
+    a: RequestRect<TimeType>,
+    b: RequestRect<TimeType>,
 }
 
-impl<TimeType: PrimInt + Signed + Display> Display for VesselOverlapError<TimeType> {
-    /// Formats the `VesselOverlapError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the details of the two overlapping vessel rectangles.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// println!("{}", error);
-    /// ```
+impl<TimeType: PrimInt + Signed + Display> Display for RequestOverlapError<TimeType> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "VesselOverlapError between {} and {}", self.a, self.b)
+        write!(f, "RequestOverlapError between {} and {}", self.a, self.b)
     }
 }
 
-impl<TimeType: PrimInt + Signed> VesselOverlapError<TimeType> {
-    /// Creates a new `VesselOverlapError` with the specified vessel rectangles.
-    ///
-    /// This function initializes a `VesselOverlapError` with the two overlapping `VesselRect` instances.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// assert_eq!(error.a(), &vessel_rect_1);
-    /// assert_eq!(error.b(), &vessel_rect_2);
-    /// ```
+impl<TimeType: PrimInt + Signed> RequestOverlapError<TimeType> {
+    /// Creates a new `RequestOverlapError`.
     #[inline]
-    pub fn new(a: VesselRect<TimeType>, b: VesselRect<TimeType>) -> Self {
+    pub fn new(a: RequestRect<TimeType>, b: RequestRect<TimeType>) -> Self {
         Self { a, b }
     }
 
-    /// Returns a reference to the first overlapping vessel rectangle.
-    ///
-    /// This function retrieves a reference to the first `VesselRect` involved in the overlap.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// assert_eq!(error.a(), &vessel_rect_1);
-    /// ```
-    pub fn a(&self) -> &VesselRect<TimeType> {
+    /// Returns the first of the two overlapping requests.
+    pub fn a(&self) -> &RequestRect<TimeType> {
         &self.a
     }
 
-    /// Returns a reference to the second overlapping vessel rectangle.
-    ///
-    /// This function retrieves a reference to the second `VesselRect` involved in the overlap.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// assert_eq!(error.b(), &vessel_rect_2);
-    /// ```
-    pub fn b(&self) -> &VesselRect<TimeType> {
+    /// Returns the second of the two overlapping requests.
+    pub fn b(&self) -> &RequestRect<TimeType> {
         &self.b
     }
 }
 
-/// Represents errors that can occur in the creation of a problem instance.
-///
-/// This enum encapsulates various error types that may arise when defining
-/// a berthing allocation problem, such as missing vessels, vessels placed
-/// out of bounds, or overlapping vessels.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{ProblemError, MissingVesselError, VesselOutOfBoundsError, VesselOverlapError, VesselRect, VesselId};
-///
-/// let missing_vessel_error: ProblemError<i64> = ProblemError::MissingVessel(MissingVesselError::new(VesselId::new(1)));
-/// println!("{}", missing_vessel_error);
-/// ```
+/// An error indicating an assignment violates the request's feasible time window.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AssignmentViolatesTimeWindow<TimeType: PrimInt + Signed> {
+    request_id: RequestId,
+    assigned: TimeInterval<TimeType>,
+    feasible: TimeInterval<TimeType>,
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for AssignmentViolatesTimeWindow<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Pre-assignment for request {} has time {} outside feasible {}",
+            self.request_id, self.assigned, self.feasible
+        )
+    }
+}
+
+impl<TimeType: PrimInt + Signed> AssignmentViolatesTimeWindow<TimeType> {
+    /// Creates a new `AssignmentViolatesTimeWindow` error.
+    pub fn new(
+        request_id: RequestId,
+        assigned: TimeInterval<TimeType>,
+        feasible: TimeInterval<TimeType>,
+    ) -> Self {
+        Self {
+            request_id,
+            assigned,
+            feasible,
+        }
+    }
+}
+
+/// An error indicating an assignment violates the request's feasible space window.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AssignmentViolatesSpaceWindow {
+    request_id: RequestId,
+    assigned: SpaceInterval,
+    feasible: SpaceInterval,
+}
+
+impl Display for AssignmentViolatesSpaceWindow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Pre-assignment for request {} has space {} outside feasible {}",
+            self.request_id, self.assigned, self.feasible
+        )
+    }
+}
+
+impl AssignmentViolatesSpaceWindow {
+    /// Creates a new `AssignmentViolatesSpaceWindow` error.
+    pub fn new(request_id: RequestId, assigned: SpaceInterval, feasible: SpaceInterval) -> Self {
+        Self {
+            request_id,
+            assigned,
+            feasible,
+        }
+    }
+}
+
+/// An error that can occur during the creation of a `Problem`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ProblemError<TimeType: PrimInt + Signed> {
-    MissingVessel(MissingVesselError),
-    VesselOutOfBounds(VesselOutOfBoundsError),
-    VesselOverlap(VesselOverlapError<TimeType>),
+    /// An entry refers to a `RequestId` not present in the set of requests.
+    MissingRequest(MissingRequestError),
+    /// A pre-assigned request is placed outside the quay's physical boundaries.
+    RequestOutOfBounds(RequestOutOfBoundsError),
+    /// Two or more pre-assigned requests overlap in time and space.
+    RequestOverlap(RequestOverlapError<TimeType>),
+    /// A pre-assigned request's time interval is outside its own feasible time window.
+    AssignmentViolatesTimeWindow(AssignmentViolatesTimeWindow<TimeType>),
+    /// A pre-assigned request's space interval is outside its own feasible space window.
+    AssignmentViolatesSpaceWindow(AssignmentViolatesSpaceWindow),
 }
 
 impl<TimeType: PrimInt + Signed + Display> Display for ProblemError<TimeType> {
-    /// Formats the `ProblemError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the details of the specific error variant.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{ProblemError, MissingVesselError, VesselId};
-    ///
-    /// let missing_vessel_error: ProblemError<i64> = ProblemError::MissingVessel(MissingVesselError::new(VesselId::new(1)));
-    /// println!("{}", missing_vessel_error);
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProblemError::MissingVessel(err) => write!(f, "{}", err),
-            ProblemError::VesselOutOfBounds(err) => write!(f, "{}", err),
-            ProblemError::VesselOverlap(err) => write!(f, "{}", err),
+            ProblemError::MissingRequest(err) => write!(f, "{}", err),
+            ProblemError::RequestOutOfBounds(err) => write!(f, "{}", err),
+            ProblemError::RequestOverlap(err) => write!(f, "{}", err),
+            ProblemError::AssignmentViolatesTimeWindow(err) => write!(f, "{}", err),
+            ProblemError::AssignmentViolatesSpaceWindow(err) => write!(f, "{}", err),
         }
     }
 }
 
 impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error for ProblemError<TimeType> {}
 
-/// Represents the Berthing Allocation Problem.
+#[inline]
+fn check_space_overlaps<T: PrimInt + Signed>(
+    rects: &[RequestRect<T>],
+) -> Result<(), RequestOverlapError<T>> {
+    if rects.is_empty() {
+        return Ok(());
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum EventKind {
+        Start,
+        End,
+    }
+    #[derive(Clone, Copy)]
+    struct Event<U: PrimInt + Signed> {
+        time: TimePoint<U>,
+        kind: EventKind,
+        rect_index: usize,
+    }
+
+    let mut events: Vec<Event<T>> = Vec::with_capacity(rects.len() * 2);
+    for (i, r) in rects.iter().enumerate() {
+        events.push(Event {
+            time: r.time_interval().start(),
+            kind: EventKind::Start,
+            rect_index: i,
+        });
+        events.push(Event {
+            time: r.time_interval().end(),
+            kind: EventKind::End,
+            rect_index: i,
+        });
+    }
+
+    // Sort by time; on ties, process End before Start so touching-in-time is allowed.
+    events.sort_by(|a, b| {
+        a.time.cmp(&b.time).then_with(|| match (a.kind, b.kind) {
+            (EventKind::End, EventKind::Start) => Ordering::Less,
+            (EventKind::Start, EventKind::End) => Ordering::Greater,
+            _ => Ordering::Equal,
+        })
+    });
+
+    let mut active: BTreeSet<(SpacePosition, usize)> = BTreeSet::new();
+
+    #[inline]
+    fn intervals_overlap(a: &SpaceInterval, b: &SpaceInterval) -> bool {
+        // Half-open [start, end): touching in space is allowed.
+        a.start() < b.end() && b.start() < a.end()
+    }
+
+    for e in events {
+        let rect = rects[e.rect_index];
+        match e.kind {
+            EventKind::Start => {
+                let key = (rect.space_interval().start(), e.rect_index);
+
+                // Check predecessor in space order.
+                if let Some(&(_, pred_idx)) = active.range(..key).next_back() {
+                    let pred = rects[pred_idx];
+                    if intervals_overlap(pred.space_interval(), rect.space_interval()) {
+                        return Err(RequestOverlapError::new(pred, rect));
+                    }
+                }
+                // Check successor in space order.
+                if let Some(&(_, succ_idx)) = active.range(key..).next() {
+                    let succ = rects[succ_idx];
+                    if intervals_overlap(succ.space_interval(), rect.space_interval()) {
+                        return Err(RequestOverlapError::new(succ, rect));
+                    }
+                }
+                active.insert(key);
+            }
+            EventKind::End => {
+                active.remove(&(rect.space_interval().start(), e.rect_index));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Defines a complete, validated berth allocation problem instance.
 ///
-/// This struct encapsulates the problem's vessels and the quay length available for berthing.
-/// It provides methods to create a new problem instance, retrieve the quay length,
-/// and access the set of vessels involved in the problem.
+/// A `Problem` consists of a set of `Request`s, their status as `ProblemEntry`s
+/// (either unassigned or pre-assigned), and the total `quay_length`. This struct
+/// is the primary input for a solver.
 #[derive(Debug, Clone)]
 pub struct Problem<TimeType = i64, CostType = i64>
 where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    vessels: HashSet<Vessel<TimeType, CostType>>,
+    requests: HashSet<Request<TimeType, CostType>>,
     entries: HashSet<ProblemEntry<TimeType>>,
     quay_length: SpaceLength,
 }
@@ -1562,578 +1017,1150 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Creates a new `Problem` instance with the specified quay length.
+    /// Creates a new `Problem` after performing comprehensive validation.
     ///
-    /// This function initializes a `Problem` with an empty set of vessels and the given quay length.
+    /// This constructor is the safe way to new a `Problem`. It ensures that all
+    /// pre-assignments are valid and do not conflict with each other or with the
+    /// problem's constraints. It uses a sweep-line algorithm to efficiently check for
+    /// overlaps among pre-assigned requests.
     ///
-    /// # Examples
+    /// # Errors
     ///
-    /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
-    /// assert!(problem.vessels().is_empty());
-    /// assert!(problem.entries().is_empty());
-    /// ```
-    #[inline]
+    /// This function returns an error if the problem definition is invalid in any way:
+    /// - `ProblemError::MissingRequest`: If an entry in `entries` refers to a `RequestId` that
+    ///   is not found in the `requests` set.
+    /// - `ProblemError::AssignmentViolatesTimeWindow`: If a pre-assignment's time allocation
+    ///   falls outside the request's own `feasible_time_window`.
+    /// - `ProblemError::AssignmentViolatesSpaceWindow`: If a pre-assignment's space allocation
+    ///   falls outside the request's own `feasible_space_window`.
+    /// - `ProblemError::RequestOutOfBounds`: If a pre-assignment would cause a request to
+    ///   extend beyond the `quay_length`.
+    /// - `ProblemError::RequestOverlap`: If any two pre-assignments overlap in both time
+    ///   and space, which is physically impossible.
     pub fn new(
-        vessels: HashSet<Vessel<TimeType, CostType>>,
+        requests: HashSet<Request<TimeType, CostType>>,
         entries: HashSet<ProblemEntry<TimeType>>,
         quay_length: SpaceLength,
     ) -> Result<Self, ProblemError<TimeType>> {
-        let vmap: HashMap<VesselId, &Vessel<TimeType, CostType>> =
-            vessels.iter().map(|v| (v.id(), v)).collect();
-        let quay_end: SpacePosition = SpacePosition::new(quay_length.value());
-
-        let rects: Vec<VesselRect<TimeType>> = entries
+        let request_map: HashMap<RequestId, &Request<TimeType, CostType>> = requests
             .iter()
-            .filter_map(|e| match e {
-                ProblemEntry::PreAssigned(a) => Some(a),
-                _ => None,
-            })
-            .map(|a| {
-                let vid = a.vessel_id();
-                let v = *vmap
-                    .get(&vid)
-                    .ok_or_else(|| ProblemError::MissingVessel(MissingVesselError::new(vid)))?;
-
-                let t0: TimePoint<TimeType> = a.berthing_time();
-                let t1: TimePoint<TimeType> = t0 + v.processing_duration();
-                let time = TimeInterval::new(t0, t1);
-
-                let x0: SpacePosition = a.berthing_position();
-                let x1: SpacePosition = x0 + v.length();
-                if x1 > quay_end {
-                    return Err(ProblemError::VesselOutOfBounds(
-                        VesselOutOfBoundsError::new(vid, x1, quay_length),
-                    ));
-                }
-                let space = SpaceInterval::new(x0, x1);
-
-                Ok(VesselRect::new(vid, time, space))
-            })
-            .collect::<Result<_, ProblemError<TimeType>>>()?;
-
-        if rects.is_empty() {
-            return Ok(Problem {
-                vessels,
-                entries,
-                quay_length,
-            });
-        }
-
-        #[derive(Clone, Copy, PartialEq, Eq)]
-        enum Kind {
-            Start,
-            End,
-        }
-
-        #[derive(Clone, Copy)]
-        struct Event<T: PrimInt> {
-            t: TimePoint<T>,
-            kind: Kind,
-            idx: usize,
-        }
-
-        let mut events: Vec<Event<TimeType>> = rects
-            .iter()
-            .enumerate()
-            .flat_map(|(i, r)| {
-                iter::once(Event {
-                    t: r.time_interval().start(),
-                    kind: Kind::Start,
-                    idx: i,
-                })
-                .chain(iter::once(Event {
-                    t: r.time_interval().end(),
-                    kind: Kind::End,
-                    idx: i,
-                }))
-            })
+            .map(|request| (request.id(), request))
             .collect();
 
-        events.sort_by(|a, b| {
-            a.t.cmp(&b.t).then_with(|| match (a.kind, b.kind) {
-                (Kind::End, Kind::Start) => Ordering::Less,
-                (Kind::Start, Kind::End) => Ordering::Greater,
-                _ => Ordering::Equal,
-            })
-        });
-        let mut active: BTreeSet<(SpacePosition, usize)> = BTreeSet::new();
-
-        #[inline]
-        fn overlaps_ho(a: &SpaceInterval, b: &SpaceInterval) -> bool {
-            a.start() < b.end() && b.start() < a.end()
-        }
-
-        for e in events {
-            let r = rects[e.idx];
-            match e.kind {
-                Kind::Start => {
-                    let key = (r.space_interval().start(), e.idx);
-
-                    if let Some(&(_, pidx)) = active.range(..key).next_back() {
-                        let pr = rects[pidx];
-                        if overlaps_ho(pr.space_interval(), r.space_interval()) {
-                            return Err(ProblemError::VesselOverlap(VesselOverlapError::new(
-                                pr, r,
-                            )));
-                        }
-                    }
-                    if let Some(&(_, sidx)) = active.range(key..).next() {
-                        let sr = rects[sidx];
-                        if overlaps_ho(sr.space_interval(), r.space_interval()) {
-                            return Err(ProblemError::VesselOverlap(VesselOverlapError::new(
-                                sr, r,
-                            )));
-                        }
-                    }
-
-                    active.insert(key);
-                }
-                Kind::End => {
-                    active.remove(&(r.space_interval().start(), e.idx));
-                }
+        // Validate that all Unassigned IDs exist in `requests`.
+        for entry in &entries {
+            if let ProblemEntry::Unassigned(id) = *entry
+                && !request_map.contains_key(&id)
+            {
+                return Err(ProblemError::MissingRequest(MissingRequestError::new(id)));
             }
         }
 
+        let quay_end_position: SpacePosition = SpacePosition::new(quay_length.value());
+
+        // Build and validate rectangles for all pre-assigned entries.
+        let pre_assigned_rects: Vec<RequestRect<TimeType>> = entries
+            .iter()
+            .filter_map(|entry| match entry {
+                ProblemEntry::PreAssigned(assignment) => Some(assignment),
+                _ => None,
+            })
+            .map(|assignment| {
+                let request_id = assignment.request_id();
+                let request = *request_map.get(&request_id).ok_or_else(|| {
+                    ProblemError::MissingRequest(MissingRequestError::new(request_id))
+                })?;
+
+                // Time-window validation
+                let berthing_time = assignment.berthing_time();
+                let departure_time = berthing_time + request.processing_duration();
+                let assigned_time_interval = TimeInterval::new(berthing_time, departure_time);
+                let feasible_time = request.feasible_time_window();
+                if !(berthing_time >= feasible_time.start()
+                    && departure_time <= feasible_time.end())
+                {
+                    return Err(ProblemError::AssignmentViolatesTimeWindow(
+                        AssignmentViolatesTimeWindow::new(
+                            request_id,
+                            assigned_time_interval,
+                            feasible_time,
+                        ),
+                    ));
+                }
+
+                // Space/window and quay-bound validation
+                let berthing_position = assignment.berthing_position();
+                let end_position = berthing_position + request.length();
+                if end_position > quay_end_position {
+                    return Err(ProblemError::RequestOutOfBounds(
+                        RequestOutOfBoundsError::new(request_id, end_position, quay_length),
+                    ));
+                }
+                let assigned_space_interval = SpaceInterval::new(berthing_position, end_position);
+                let feasible_space = request.feasible_space_window();
+                if !(berthing_position >= feasible_space.start()
+                    && end_position <= feasible_space.end())
+                {
+                    return Err(ProblemError::AssignmentViolatesSpaceWindow(
+                        AssignmentViolatesSpaceWindow::new(
+                            request_id,
+                            assigned_space_interval,
+                            feasible_space,
+                        ),
+                    ));
+                }
+
+                Ok(RequestRect::new(
+                    request_id,
+                    assigned_time_interval,
+                    assigned_space_interval,
+                ))
+            })
+            .collect::<Result<_, ProblemError<TimeType>>>()?;
+
+        // Check overlaps among pre-assigned rectangles (time-sweep + space-neighbor check).
+        if !pre_assigned_rects.is_empty() {
+            check_space_overlaps(&pre_assigned_rects).map_err(ProblemError::RequestOverlap)?;
+        }
+
         Ok(Problem {
-            vessels,
+            requests,
             entries,
             quay_length,
         })
     }
 
-    /// Returns the quay length of the problem.
-    ///
-    /// This function retrieves the `SpaceLength` representing the length of the quay available for berthing vessels.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
-    /// ```
+    /// Returns the total physical length of the quay.
     #[inline]
     pub fn quay_length(&self) -> SpaceLength {
         self.quay_length
     }
 
-    /// Returns a reference to the set of vessels in the problem.
-    ///
-    /// This function provides access to the `HashSet` of vessels, allowing iteration or inspection of the vessels involved in the problem.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert!(problem.vessels().is_empty());
-    /// ```
+    /// Returns a reference to the set of all requests in the problem.
     #[inline]
-    pub fn vessels(&self) -> &HashSet<Vessel<TimeType, CostType>> {
-        &self.vessels
+    pub fn requests(&self) -> &HashSet<Request<TimeType, CostType>> {
+        &self.requests
     }
 
-    /// Returns a reference to the set of problem entries.
-    ///
-    /// This function provides access to the `HashSet` of problem entries,
-    /// allowing iteration or inspection of the entries involved in the problem.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert!(problem.entries().is_empty());
-    /// ```
+    /// Returns a reference to the set of all problem entries.
     #[inline]
     pub fn entries(&self) -> &HashSet<ProblemEntry<TimeType>> {
         &self.entries
     }
 
-    /// Returns the number of vessels in the problem.
-    ///
-    /// This function returns the count of vessels currently stored in the problem's vessel set.
+    /// Returns the total number of requests in the problem.
+    #[inline]
+    pub fn request_len(&self) -> usize {
+        self.requests.len()
+    }
+}
+
+/// A type alias for the most common problem definition using `i64` for time and cost.
+pub type BerthAllocationProblem = Problem<i64, i64>;
+
+/// Represents a solver's decision for a single request.
+///
+/// A decision can either be to `Assign` the request to a specific time and place,
+/// or to `Drop` it if the request is droppable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Decision<TimeType = i64>
+where
+    TimeType: PrimInt + Signed,
+{
+    /// Assign the request to a specific time and position.
+    Assign(Assignment<TimeType>),
+    /// Drop the request (only valid for droppable requests).
+    Drop(RequestId),
+}
+
+impl<T: PrimInt + Signed> From<Assignment<T>> for Decision<T> {
+    fn from(a: Assignment<T>) -> Self {
+        Decision::Assign(a)
+    }
+}
+
+impl<TimeType> Decision<TimeType>
+where
+    TimeType: PrimInt + Signed,
+{
+    /// Returns the `RequestId` associated with this decision.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Problem, Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
+    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+    /// use dock_alloc_model::{Decision, Assignment, RequestId};
     ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert_eq!(problem.vessel_len(), 0);
+    /// let assign_decision: Decision<i64> = Decision::Assign(Assignment::new(
+    ///     RequestId::new(1),
+    ///     SpacePosition::new(100),
+    ///     TimePoint::new(1000i64)
+    /// ));
+    /// let drop_decision: Decision<i64> = Decision::Drop(RequestId::new(2));
+    ///
+    /// assert_eq!(assign_decision.request_id(), RequestId::new(1));
+    /// assert_eq!(drop_decision.request_id(), RequestId::new(2));
     /// ```
     #[inline]
-    pub fn vessel_len(&self) -> usize {
-        self.vessels.len()
+    pub fn request_id(&self) -> RequestId {
+        match *self {
+            Decision::Assign(assignment) => assignment.request_id(),
+            Decision::Drop(request_id) => request_id,
+        }
     }
 }
 
-/// Type alias for the Berthing Allocation Problem with default types for time and cost.
+/// An error indicating that a solver's decision for a pre-assigned request differs from its fixed assignment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PreassignedChangedError<TimeType: PrimInt + Signed> {
+    request_id: RequestId,
+    expected: (TimePoint<TimeType>, SpacePosition),
+    actual: (TimePoint<TimeType>, SpacePosition),
+}
+
+impl<TimeType: PrimInt + Signed> PreassignedChangedError<TimeType> {
+    /// Creates a new `PreassignedChangedError`.
+    pub fn new(
+        request_id: RequestId,
+        expected: (TimePoint<TimeType>, SpacePosition),
+        actual: (TimePoint<TimeType>, SpacePosition),
+    ) -> Self {
+        Self {
+            request_id,
+            expected,
+            actual,
+        }
+    }
+
+    /// Returns the ID of the request whose pre-assignment was changed.
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    /// Returns the expected (time, position) tuple.
+    pub fn expected(&self) -> &(TimePoint<TimeType>, SpacePosition) {
+        &self.expected
+    }
+
+    /// Returns the actual (time, position) tuple provided by the solver.
+    pub fn actual(&self) -> &(TimePoint<TimeType>, SpacePosition) {
+        &self.actual
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for PreassignedChangedError<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Pre-assignment for request {} changed: expected position {} at time {}, got position {} at time {}",
+            self.request_id, self.expected.1, self.expected.0, self.actual.1, self.actual.0
+        )
+    }
+}
+
+/// An error that can occur during the validation and newing of a `Solution`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolutionError<TimeType: PrimInt + Signed> {
+    /// A decision was made for a `RequestId` that does not exist in the problem.
+    UnknownRequest(RequestId),
+    /// More than one decision was made for the same `RequestId`.
+    DuplicateDecision(RequestId),
+    /// An unassigned request in the problem did not have a corresponding decision.
+    MissingDecision(RequestId),
+    /// A solver's decision for a pre-assigned request was different from its fixed assignment.
+    PreassignmentChanged(PreassignedChangedError<TimeType>),
+    /// A solver's decision was to drop a request that was pre-assigned.
+    PreassignedDropped(RequestId),
+    /// A solver's decision was to drop a request that was not marked as droppable.
+    DroppedNotDroppable(RequestId),
+    /// An assignment resulted in a berthing time earlier than the request's arrival time.
+    NegativeWaitingTime(RequestId),
+    /// An assignment's time interval violates the request's feasible time window.
+    AssignmentViolatesTimeWindow(AssignmentViolatesTimeWindow<TimeType>),
+    /// An assignment's space interval violates the request's feasible space window.
+    AssignmentViolatesSpaceWindow(AssignmentViolatesSpaceWindow),
+    /// An assignment places a request outside the physical quay boundaries.
+    RequestOutOfBounds(RequestOutOfBoundsError),
+    /// Two assignments in the final solution overlap in both time and space.
+    RequestOverlap(RequestOverlapError<TimeType>),
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for SolutionError<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use SolutionError::*;
+        match self {
+            UnknownRequest(id) => write!(f, "Decision references unknown request {}", id),
+            DuplicateDecision(id) => write!(f, "Duplicate decision for request {}", id),
+            MissingDecision(id) => write!(f, "Missing decision for unassigned request {}", id),
+            PreassignmentChanged(err) => write!(f, "{}", err),
+            PreassignedDropped(id) => write!(f, "Pre-assigned request {} cannot be dropped", id),
+            DroppedNotDroppable(id) => write!(f, "Request {} is not droppable", id),
+            NegativeWaitingTime(id) => write!(f, "Waiting time would be negative for {}", id),
+            AssignmentViolatesTimeWindow(err) => write!(f, "{}", err),
+            AssignmentViolatesSpaceWindow(err) => write!(f, "{}", err),
+            RequestOutOfBounds(err) => write!(f, "{}", err),
+            RequestOverlap(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error for SolutionError<TimeType> {}
+
+/// Contains aggregated statistics about a `Solution`.
 ///
-/// This alias simplifies the usage of the `Problem` struct by providing a default type for time and cost,
-/// which are both `i64`.
-pub type BerthAllocationProblem = Problem<i64, i64>;
+/// This includes the total cost and other key performance indicators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SolutionStats<TimeType = i64, CostType = i64>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    total_cost: Cost<CostType>,
+    total_waiting_time: TimeDelta<TimeType>,
+    total_target_position_deviation: SpaceLength,
+    total_dropped_requests: usize,
+}
+
+impl<TimeType, CostType> SolutionStats<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    /// Returns the total cost of the solution.
+    ///
+    /// This cost is the sum of all waiting costs, position deviation costs, and drop penalties.
+    #[inline]
+    pub fn total_cost(&self) -> Cost<CostType> {
+        self.total_cost
+    }
+
+    /// Returns the sum of waiting times for all assigned requests.
+    #[inline]
+    pub fn total_waiting_time(&self) -> TimeDelta<TimeType> {
+        self.total_waiting_time
+    }
+
+    /// Returns the sum of absolute deviations from target positions for all assigned requests.
+    #[inline]
+    pub fn total_target_position_deviation(&self) -> SpaceLength {
+        self.total_target_position_deviation
+    }
+
+    /// Returns the total number of requests that were dropped.
+    #[inline]
+    pub fn total_dropped_requests(&self) -> usize {
+        self.total_dropped_requests
+    }
+}
+
+/// Represents a complete, validated solution to a `Problem`.
+///
+/// A `Solution` contains the set of `Decision`s for each request and the calculated
+/// `SolutionStats`. It can only be constructed via the `new` function, which
+/// ensures the solution is valid and consistent with the problem definition.
+#[derive(Debug, Clone)]
+pub struct Solution<TimeType = i64, CostType = i64>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed,
+{
+    decisions: HashMap<RequestId, Decision<TimeType>>,
+    stats: SolutionStats<TimeType, CostType>,
+}
+
+impl<TimeType, CostType> Solution<TimeType, CostType>
+where
+    TimeType: PrimInt + Signed,
+    CostType: PrimInt + Signed + TryFrom<TimeType> + TryFrom<usize>,
+{
+    /// Validates a set of `Decision`s against a `Problem` and news a `Solution`.
+    ///
+    /// This is the primary way to create a `Solution`. It performs an exhaustive set of
+    /// checks to ensure that the provided decisions constitute a feasible and valid solution
+    /// to the given problem. If validation succeeds, it calculates solution statistics and
+    /// returns the `Solution`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if any of the validation checks fail. See `SolutionError` for a
+    /// complete list of possible failures.
+    pub fn new(
+        problem: &Problem<TimeType, CostType>,
+        decisions: impl IntoIterator<Item = Decision<TimeType>>,
+    ) -> Result<Self, SolutionError<TimeType>> {
+        let request_map: HashMap<RequestId, &Request<TimeType, CostType>> = problem
+            .requests()
+            .iter()
+            .map(|req| (req.id(), req))
+            .collect();
+
+        // Partition problem entries.
+        let mut preassigned_map: HashMap<RequestId, Assignment<TimeType>> = HashMap::new();
+        let mut unassigned_set: HashSet<RequestId> = HashSet::new();
+        for entry in problem.entries() {
+            match *entry {
+                ProblemEntry::PreAssigned(a) => {
+                    preassigned_map.insert(a.request_id(), a);
+                }
+                ProblemEntry::Unassigned(id) => {
+                    unassigned_set.insert(id);
+                }
+            }
+        }
+
+        let mut seen_ids: HashSet<RequestId> = HashSet::new();
+        let mut decisions_map: HashMap<RequestId, Decision<TimeType>> = HashMap::new();
+
+        // Validate incoming decisions and normalize into a map.
+        for decision in decisions {
+            let request_id = decision.request_id();
+            if !request_map.contains_key(&request_id) {
+                return Err(SolutionError::UnknownRequest(request_id));
+            }
+            if !seen_ids.insert(request_id) {
+                return Err(SolutionError::DuplicateDecision(request_id));
+            }
+
+            match decision {
+                Decision::Assign(a) => {
+                    if let Some(exp) = preassigned_map.get(&request_id)
+                        && (exp.berthing_position() != a.berthing_position()
+                            || exp.berthing_time() != a.berthing_time())
+                    {
+                        return Err(SolutionError::PreassignmentChanged(
+                            PreassignedChangedError::new(
+                                request_id,
+                                (exp.berthing_time(), exp.berthing_position()),
+                                (a.berthing_time(), a.berthing_position()),
+                            ),
+                        ));
+                    }
+                    decisions_map.insert(request_id, Decision::Assign(a));
+                }
+                Decision::Drop(id) => {
+                    if preassigned_map.contains_key(&id) {
+                        return Err(SolutionError::PreassignedDropped(id));
+                    }
+                    let req = request_map[&id];
+                    if !req.is_droppable() {
+                        return Err(SolutionError::DroppedNotDroppable(id));
+                    }
+                    decisions_map.insert(request_id, Decision::Drop(id));
+                }
+            }
+        }
+
+        // Ensure all Unassigned have a decision.
+        for &id in &unassigned_set {
+            if !seen_ids.contains(&id) {
+                return Err(SolutionError::MissingDecision(id));
+            }
+        }
+
+        // Ensure pre-assigned are present, even if not explicitly provided.
+        for (&id, &assign) in &preassigned_map {
+            decisions_map.entry(id).or_insert(Decision::Assign(assign));
+        }
+
+        // Collect final assignments for validation/costing.
+        let mut final_assignments: HashMap<RequestId, Assignment<TimeType>> = HashMap::new();
+        for (&id, decision) in &decisions_map {
+            if let Decision::Assign(a) = decision {
+                final_assignments.insert(id, *a);
+            }
+        }
+
+        let quay_end = SpacePosition::new(problem.quay_length().value());
+        let mut assigned_rects: Vec<RequestRect<TimeType>> = Vec::new();
+        let mut total_cost: Cost<CostType> = Cost::zero();
+        let mut total_waiting_time: TimeDelta<TimeType> = TimeDelta::new(TimeType::zero());
+        let mut total_position_deviation: SpaceLength = SpaceLength::new(0);
+
+        for (&request_id, &assignment) in &final_assignments {
+            let request = request_map[&request_id];
+
+            // Time-window validation.
+            let berthing_time = assignment.berthing_time();
+            let departure_time = berthing_time + request.processing_duration();
+            let assigned_time = TimeInterval::new(berthing_time, departure_time);
+            let feasible_time = request.feasible_time_window();
+            if !(berthing_time >= feasible_time.start() && departure_time <= feasible_time.end()) {
+                return Err(SolutionError::AssignmentViolatesTimeWindow(
+                    AssignmentViolatesTimeWindow::new(request_id, assigned_time, feasible_time),
+                ));
+            }
+
+            // Space and quay-bound validation.
+            let berthing_position = assignment.berthing_position();
+            let end_position = berthing_position + request.length();
+            if end_position > quay_end {
+                return Err(SolutionError::RequestOutOfBounds(
+                    RequestOutOfBoundsError::new(request_id, end_position, problem.quay_length()),
+                ));
+            }
+            let assigned_space = SpaceInterval::new(berthing_position, end_position);
+            let feasible_space = request.feasible_space_window();
+            if !(berthing_position >= feasible_space.start()
+                && end_position <= feasible_space.end())
+            {
+                return Err(SolutionError::AssignmentViolatesSpaceWindow(
+                    AssignmentViolatesSpaceWindow::new(request_id, assigned_space, feasible_space),
+                ));
+            }
+
+            // Logical validation and costs.
+            let waiting_time = berthing_time - request.arrival_time();
+            if waiting_time.value() < TimeType::zero() {
+                return Err(SolutionError::NegativeWaitingTime(request_id));
+            }
+
+            // Use typed absolute distance (requires SpacePosition::distance_to).
+            let position_deviation = berthing_position - request.target_position();
+
+            total_cost = total_cost
+                + request.waiting_cost(waiting_time)
+                + request.target_position_deviation_cost(position_deviation);
+            total_waiting_time += waiting_time;
+            total_position_deviation += position_deviation;
+
+            assigned_rects.push(RequestRect::new(request_id, assigned_time, assigned_space));
+        }
+
+        // Add drop penalties.
+        let mut dropped_count = 0usize;
+        for (&request_id, decision) in &decisions_map {
+            if let Decision::Drop(_) = decision {
+                dropped_count += 1;
+                if let Some(penalty) = request_map[&request_id].drop_penalty() {
+                    total_cost += penalty;
+                }
+            }
+        }
+
+        // Overlap check for all assignments.
+        if !assigned_rects.is_empty() {
+            check_space_overlaps(&assigned_rects).map_err(SolutionError::RequestOverlap)?;
+        }
+
+        let stats = SolutionStats {
+            total_cost,
+            total_waiting_time,
+            total_target_position_deviation: total_position_deviation,
+            total_dropped_requests: dropped_count,
+        };
+
+        Ok(Solution {
+            decisions: decisions_map,
+            stats,
+        })
+    }
+
+    /// Returns a reference to the solution's statistics.
+    #[inline]
+    pub fn stats(&self) -> &SolutionStats<TimeType, CostType> {
+        &self.stats
+    }
+
+    /// Returns a map of all decisions made for the requests.
+    #[inline]
+    pub fn decisions(&self) -> &HashMap<RequestId, Decision<TimeType>> {
+        &self.decisions
+    }
+
+    /// Returns an iterator over all assigned requests and their assignments.
+    pub fn assigned(&self) -> impl Iterator<Item = (&RequestId, &Assignment<TimeType>)> {
+        self.decisions
+            .iter()
+            .filter_map(|(id, decision)| match decision {
+                Decision::Assign(assignment) => Some((id, assignment)),
+                _ => None,
+            })
+    }
+
+    /// Returns an iterator over all dropped request IDs.
+    pub fn dropped(&self) -> impl Iterator<Item = RequestId> {
+        self.decisions
+            .iter()
+            .filter_map(|(_, decision)| match decision {
+                Decision::Drop(request_id) => Some(*request_id),
+                _ => None,
+            })
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_vessel_id_creation() {
-        let id = VesselId::new(42);
+    fn test_request_id_creation() {
+        let id = RequestId::new(42);
         assert_eq!(id.value(), 42);
     }
-
     #[test]
-    fn test_vessel_id_display() {
-        let id = VesselId::new(42);
-        assert_eq!(format!("{}", id), "VesselId(42)");
+    fn test_request_id_display() {
+        let id = RequestId::new(42);
+        assert_eq!(format!("{}", id), "RequestId(42)");
     }
-
     #[test]
-    fn test_vessel_id_equality() {
-        let id1 = VesselId::new(42);
-        let id2 = VesselId::new(42);
+    fn test_request_id_equality() {
+        let id1 = RequestId::new(42);
+        let id2 = RequestId::new(42);
         assert_eq!(id1, id2);
     }
-
     #[test]
-    fn test_vessel_id_from_u64() {
-        let id: VesselId = 42.into();
+    fn test_request_id_from_u64() {
+        let id: RequestId = 42.into();
         assert_eq!(id.value(), 42);
     }
 
     #[test]
-    fn test_vessel_display() {
-        let vessel = Vessel::new(
-            VesselId::new(1),
+    fn test_request_display() {
+        let start = TimePoint::new(1_622_547_800_i64);
+        let proc = TimeDelta::new(3600_i64);
+        let tw = TimeInterval::new(start, start + proc); // exactly fits
+        let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(10_000));
+
+        let request = Request::new(
+            RequestId::new(1),
             SpaceLength::new(100),
-            TimePoint::new(1622547800),
-            TimeDelta::new(3600),
+            proc,
             SpacePosition::new(50),
             Cost::new(10),
             Cost::new(5),
-        );
+            tw,
+            sw,
+            None,
+        )
+        .unwrap();
+
         assert_eq!(
-            format!("{}", vessel),
-            "Vessel(id: VesselId(1), \
+            format!("{}", request),
+            "Request(id: RequestId(1), \
             length: SpaceLength(100), \
             arrival_time: TimePoint(1622547800), \
             processing_duration: TimeDelta(3600), \
-            target_berthing_position: SpacePosition(50), \
-            cost_per_waiting_time: Cost(10), \
-            cost_per_target_berthing_deviation: Cost(5))"
+            target_position: SpacePosition(50), \
+            cost_per_delay: Cost(10), \
+            cost_per_position_deviation: Cost(5))"
         );
-    }
-
-    #[test]
-    fn test_vessels_are_unique_by_id() {
-        let mut set = std::collections::HashSet::new();
-        let v1 = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(0),
-            TimeDelta::new(10),
-            SpacePosition::new(0),
-            Cost::new(1),
-            Cost::new(1),
-        );
-        let v2 = Vessel::new(
-            // same id, different fields
-            VesselId::new(1),
-            SpaceLength::new(200),
-            TimePoint::new(5),
-            TimeDelta::new(20),
-            SpacePosition::new(10),
-            Cost::new(2),
-            Cost::new(3),
-        );
-        set.insert(v1);
-        set.insert(v2);
-        assert_eq!(set.len(), 1);
     }
 
     #[test]
     fn test_waiting_cost() {
-        let vessel = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(1622547800),
-            TimeDelta::new(3600),
-            SpacePosition::new(50),
-            Cost::new(10),
-            Cost::new(5),
-        );
+        let request = create_test_request::<i64>(1, 100, 3600, 0, 50);
         let waiting_time = TimeDelta::new(2);
-        let cost = vessel.waiting_cost(waiting_time);
-        assert_eq!(cost.value(), 20); // 10 * 2
+        let cost = request.waiting_cost(waiting_time);
+        assert_eq!(cost.value(), 2); // helper sets cost per unit = 1
     }
 
     #[test]
-    fn test_target_berthing_deviation_cost() {
-        let vessel = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(1622547800),
-            TimeDelta::new(3600),
-            SpacePosition::new(50),
-            Cost::new(10),
-            Cost::new(5),
-        );
+    fn test_target_position_deviation_cost() {
+        let request = create_test_request::<i64>(1, 100, 3600, 0, 50);
         let deviation = SpaceLength::new(3);
-        let cost = vessel.target_berthing_deviation_cost(deviation);
-        assert_eq!(cost.value(), 15); // 5 * 3
+        let cost = request.target_position_deviation_cost(deviation);
+        assert_eq!(cost.value(), 3);
     }
 
     #[test]
     fn test_assignment_display() {
         let assignment = Assignment::new(
-            VesselId::new(1),
+            RequestId::new(1),
             SpacePosition::new(100),
             TimePoint::new(1622547800),
         );
         assert_eq!(
             format!("{}", assignment),
-            "Assignment(vessel_id: VesselId(1), \
+            "Assignment(request_id: RequestId(1), \
             berthing_position: SpacePosition(100), \
             berthing_time: TimePoint(1622547800))"
         );
     }
 
-    fn v<T: PrimInt + Signed>(id: u64, len: usize, proc: T, arr: T, tgt: usize) -> Vessel<T, i64> {
-        Vessel::new(
-            VesselId::new(id),
-            SpaceLength::new(len),
+    fn create_test_request<T: PrimInt + Signed + Debug>(
+        id: u64,
+        len: usize,
+        proc: T,
+        arr: T,
+        tgt: usize,
+    ) -> Request<T, i64> {
+        // Feasible time window: [arr, arr+proc+100) so it always fits
+        let tw = TimeInterval::new(
             TimePoint::new(arr),
+            TimePoint::new(arr + proc + T::from(100).unwrap()),
+        );
+        // Wide feasible space window
+        let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(10_000));
+        Request::new(
+            RequestId::new(id),
+            SpaceLength::new(len),
             TimeDelta::new(proc),
             SpacePosition::new(tgt),
             Cost::new(1),
             Cost::new(1),
+            tw,
+            sw,
+            None,
         )
+        .unwrap()
     }
 
-    fn a<T: PrimInt + Signed>(id: u64, x0: usize, t0: T) -> ProblemEntry<T> {
+    fn create_test_pre_assignment_entry<T: PrimInt + Signed>(
+        id: u64,
+        x0: usize,
+        t0: T,
+    ) -> ProblemEntry<T> {
         ProblemEntry::PreAssigned(Assignment::new(
-            VesselId::new(id),
+            RequestId::new(id),
             SpacePosition::new(x0),
             TimePoint::new(t0),
         ))
     }
 
-    fn hs<T>(items: impl IntoIterator<Item = T>) -> HashSet<T>
+    fn to_hashset<T>(items: impl IntoIterator<Item = T>) -> HashSet<T>
     where
         T: Eq + Hash,
     {
         items.into_iter().collect()
     }
 
-    // ---------- tests ----------
-
-    /// No pre-assignments → always OK.
     #[test]
-    fn new_ok_no_entries() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0)]);
+    fn test_request_new_err_time_window_too_short() {
+        let tw = TimeInterval::new(TimePoint::new(0_i64), TimePoint::new(5_i64));
+        let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(1_000));
+        let err = Request::<i64, i64>::new(
+            RequestId::new(1),
+            SpaceLength::new(10),
+            TimeDelta::new(10),
+            SpacePosition::new(0),
+            Cost::new(1),
+            Cost::new(1),
+            tw,
+            sw,
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            super::RequestCreationError::TimeWindowTooShort(_)
+        ));
+    }
+
+    #[test]
+    fn test_request_new_err_space_window_too_short() {
+        let tw = TimeInterval::new(TimePoint::new(0_i64), TimePoint::new(100_i64));
+        let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(50));
+        let err = Request::<i64, i64>::new(
+            RequestId::new(1),
+            SpaceLength::new(60),
+            TimeDelta::new(10),
+            SpacePosition::new(0),
+            Cost::new(1),
+            Cost::new(1),
+            tw,
+            sw,
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            super::RequestCreationError::SpaceWindowTooShort(_)
+        ));
+    }
+
+    #[test]
+    fn test_new_ok_no_entries() {
+        let requests = to_hashset([create_test_request::<i64>(1, 100, 10, 0, 0)]);
         let entries = HashSet::new();
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Single pre-assignment within quay bounds.
     #[test]
     fn new_ok_single_preassignment_in_bounds() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0)]);
-        let entries = hs([a::<i64>(1, 50, 5)]);
+        let requests = to_hashset([create_test_request::<i64>(1, 100, 10, 0, 0)]);
+        let entries = to_hashset([create_test_pre_assignment_entry::<i64>(1, 50, 5)]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Pre-assigned vessel not present in vessels set → MissingVessel error.
     #[test]
-    fn new_err_missing_vessel() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0)]);
-        let entries = hs([a::<i64>(2, 50, 5)]); // vessel 2 does not exist
+    fn test_new_err_missing_request() {
+        let requests = to_hashset([create_test_request::<i64>(1, 100, 10, 0, 0)]);
+        let entries = to_hashset([create_test_pre_assignment_entry::<i64>(2, 50, 5)]); // request 2 does not exist
         let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::MissingVessel(_));
+        let err = Problem::new(requests, entries, quay).unwrap_err();
+        assert!(matches!(err, ProblemError::MissingRequest(_)));
     }
 
-    /// End position (x0 + len) past quay_end → VesselOutOfBounds error.
     #[test]
-    fn new_err_out_of_bounds() {
-        let vessels = hs([v::<i64>(1, 200, 10, 0, 0)]);
-        // put the ship near the end so x1 > quay_end
-        let entries = hs([a::<i64>(1, 900, 0)]);
+    fn test_new_err_out_of_bounds() {
+        let requests = to_hashset([create_test_request::<i64>(1, 200, 10, 0, 0)]);
+        let entries = to_hashset([create_test_pre_assignment_entry::<i64>(1, 900, 0)]);
         let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::VesselOutOfBounds(_));
+        let err = Problem::new(requests, entries, quay).unwrap_err();
+        assert!(matches!(err, ProblemError::RequestOutOfBounds(_)));
     }
 
-    /// Touching in time (t1 == t0') with same space overlap is allowed (half-open time).
     #[test]
-    fn new_ok_touching_in_time_same_space() {
-        // both length 100 at same x0
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // first: [t=0,10), second: starts at 10
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 100, 10)]);
+    fn test_new_ok_touching_in_time_same_space() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 100, 10, 0, 0),
+            create_test_request::<i64>(2, 100, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 100, 0),
+            create_test_pre_assignment_entry::<i64>(2, 100, 10),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Touching in space (x1 == x0') during overlapping time is allowed (half-open space).
     #[test]
-    fn new_ok_touching_in_space_same_time() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // same time window, adjacent in space: [100,200) and [200,300)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 200, 0)]);
+    fn test_new_ok_touching_in_space_same_time() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 100, 10, 0, 0),
+            create_test_request::<i64>(2, 100, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 100, 0),
+            create_test_pre_assignment_entry::<i64>(2, 200, 0),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Overlap in both time and space → VesselOverlap error.
     #[test]
-    fn new_err_overlap_in_time_and_space() {
-        let vessels = hs([v::<i64>(1, 150, 10, 0, 0), v::<i64>(2, 150, 10, 0, 0)]);
-        // same time window [0,10), space [100,250) vs [200,350) → overlap [200,250)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 200, 0)]);
+    fn test_new_err_overlap_in_time_and_space() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 150, 10, 0, 0),
+            create_test_request::<i64>(2, 150, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 100, 0),
+            create_test_pre_assignment_entry::<i64>(2, 200, 0),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::VesselOverlap(_));
+        let err = Problem::new(requests, entries, quay).unwrap_err();
+        assert!(matches!(err, ProblemError::RequestOverlap(_)));
     }
 
-    /// Overlap in time only (space disjoint) → OK.
     #[test]
-    fn new_ok_overlap_time_only() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // time overlaps, but space disjoint: [100,200) vs [300,400)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 300, 5)]);
+    fn test_new_ok_overlap_time_only() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 100, 10, 0, 0),
+            create_test_request::<i64>(2, 100, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 100, 0),
+            create_test_pre_assignment_entry::<i64>(2, 300, 5),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Overlap in space only (time disjoint) → OK.
     #[test]
-    fn new_ok_overlap_space_only() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // same space [100,200) but time-disjoint: [0,10) and [10,20)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 100, 10)]);
+    fn test_new_ok_overlap_space_only() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 100, 10, 0, 0),
+            create_test_request::<i64>(2, 100, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 100, 0),
+            create_test_pre_assignment_entry::<i64>(2, 100, 10),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// End-before-Start tie handling: an assignment ending at t lets another
-    /// start at the same t without overlap.
     #[test]
     fn new_ok_end_before_start_tie() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // [0,10) then [10,20) at same space
-        let entries = hs([a::<i64>(1, 500, 0), a::<i64>(2, 500, 10)]);
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 100, 10, 0, 0),
+            create_test_request::<i64>(2, 100, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 500, 0),
+            create_test_pre_assignment_entry::<i64>(2, 500, 10),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Neighbor check robustness: inserting a rect whose space lies between two active neighbors.
     #[test]
-    fn new_ok_non_overlapping_middle_insert() {
-        // three ships length 50; middle fits exactly between neighbors
-        let vessels = hs([
-            v::<i64>(1, 50, 10, 0, 0),
-            v::<i64>(2, 50, 10, 0, 0),
-            v::<i64>(3, 50, 10, 0, 0),
+    fn test_new_ok_non_overlapping_middle_insert() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 50, 10, 0, 0),
+            create_test_request::<i64>(2, 50, 10, 0, 0),
+            create_test_request::<i64>(3, 50, 10, 0, 0),
         ]);
-        // all overlap in time; spaces are [100,150), [150,200), [200,250)
-        let entries = hs([
-            a::<i64>(1, 100, 0),
-            a::<i64>(2, 150, 0),
-            a::<i64>(3, 200, 0),
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 100, 0),
+            create_test_pre_assignment_entry::<i64>(2, 150, 0),
+            create_test_pre_assignment_entry::<i64>(3, 200, 0),
         ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
     }
 
-    /// Overlap with equal x0: ensures we still detect overlap when two ships start at the same space start
-    /// and their times overlap.
     #[test]
-    fn new_err_equal_x0_overlapping_time() {
-        let vessels = hs([v::<i64>(1, 80, 10, 0, 0), v::<i64>(2, 80, 10, 0, 0)]);
-        // same x0, time windows overlap → overlap in space and time
-        let entries = hs([a::<i64>(1, 300, 0), a::<i64>(2, 300, 5)]);
+    fn test_new_err_equal_x0_overlapping_time() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 80, 10, 0, 0),
+            create_test_request::<i64>(2, 80, 10, 0, 0),
+        ]);
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 300, 0),
+            create_test_pre_assignment_entry::<i64>(2, 300, 5),
+        ]);
         let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::VesselOverlap(_));
+        let err = Problem::new(requests, entries, quay).unwrap_err();
+        assert!(matches!(err, ProblemError::RequestOverlap(_)));
     }
 
-    /// Many non-overlapping assignments in shuffled order (stress ordering & sorting).
     #[test]
-    fn new_ok_many_nonoverlapping_shuffled() {
-        let vessels = hs([
-            v::<i64>(1, 60, 7, 0, 0),
-            v::<i64>(2, 60, 7, 0, 0),
-            v::<i64>(3, 60, 7, 0, 0),
-            v::<i64>(4, 60, 7, 0, 0),
+    fn test_new_ok_many_nonoverlapping_shuffled() {
+        let requests = to_hashset([
+            create_test_request::<i64>(1, 60, 7, 0, 0),
+            create_test_request::<i64>(2, 60, 7, 0, 0),
+            create_test_request::<i64>(3, 60, 7, 0, 0),
+            create_test_request::<i64>(4, 60, 7, 0, 0),
         ]);
-        // Shuffle events across time and space but keep disjoint in at least one dimension pairwise.
-        let entries = hs([
-            // time [0,7), space [0,60)
-            a::<i64>(1, 0, 0),
-            // time [5,12) but space disjoint: [120,180)
-            a::<i64>(2, 120, 5),
-            // time [12,19), same space as #1 (OK — time disjoint)
-            a::<i64>(3, 0, 12),
-            // time [10,17), space touches #2: [180,240) (OK — space touching)
-            a::<i64>(4, 180, 10),
+        let entries = to_hashset([
+            create_test_pre_assignment_entry::<i64>(1, 0, 0),
+            create_test_pre_assignment_entry::<i64>(2, 120, 5),
+            create_test_pre_assignment_entry::<i64>(3, 0, 12),
+            create_test_pre_assignment_entry::<i64>(4, 180, 10),
         ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(requests, entries, quay);
         assert!(p.is_ok());
+    }
+
+    #[test]
+    fn new_err_assignment_violates_time_window() {
+        let v1 = {
+            let tw = TimeInterval::new(TimePoint::new(0_i64), TimePoint::new(10_i64));
+            let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(1_000));
+            Request::new(
+                RequestId::new(1),
+                SpaceLength::new(100),
+                TimeDelta::new(5),
+                SpacePosition::new(0),
+                Cost::new(1),
+                Cost::new(1),
+                tw,
+                sw,
+                None,
+            )
+            .unwrap()
+        };
+        let entries = to_hashset([create_test_pre_assignment_entry::<i64>(1, 0, 7)]);
+        let quay = SpaceLength::new(1_000);
+        let err = Problem::new(to_hashset([v1]), entries, quay).unwrap_err();
+        assert!(matches!(err, ProblemError::AssignmentViolatesTimeWindow(_)));
+    }
+
+    #[test]
+    fn test_new_err_assignment_violates_space_window() {
+        let v1 = {
+            let tw = TimeInterval::new(TimePoint::new(0_i64), TimePoint::new(100_i64));
+            let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(150));
+            Request::new(
+                RequestId::new(1),
+                SpaceLength::new(100),
+                TimeDelta::new(5),
+                SpacePosition::new(0),
+                Cost::new(1),
+                Cost::new(1),
+                tw,
+                sw,
+                None,
+            )
+            .unwrap()
+        };
+        let entries = to_hashset([create_test_pre_assignment_entry::<i64>(1, 100, 0)]);
+        let quay = SpaceLength::new(1_000);
+        let err = Problem::new(to_hashset([v1]), entries, quay).unwrap_err();
+        assert!(matches!(
+            err,
+            ProblemError::AssignmentViolatesSpaceWindow(_)
+        ));
+    }
+
+    fn mk_request<T: PrimInt + Signed + Debug>(
+        id: u64,
+        len: usize,
+        proc: T,
+        arr: T,
+        tgt: usize,
+        droppable: bool,
+    ) -> Request<T, i64> {
+        let tw = TimeInterval::new(
+            TimePoint::new(arr),
+            TimePoint::new(arr + proc + T::from(100).unwrap()),
+        );
+        let sw = SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(10_000));
+        Request::new(
+            RequestId::new(id),
+            SpaceLength::new(len),
+            TimeDelta::new(proc),
+            SpacePosition::new(tgt),
+            Cost::new(1),
+            Cost::new(1),
+            tw,
+            sw,
+            if droppable { Some(Cost::new(7)) } else { None },
+        )
+        .unwrap()
+    }
+
+    fn hs<T>(it: impl IntoIterator<Item = T>) -> HashSet<T>
+    where
+        T: Eq + Hash,
+    {
+        it.into_iter().collect()
+    }
+
+    #[test]
+    fn solution_new_ok_assign_and_drop() {
+        let v1 = mk_request::<i64>(1, 100, 10, 0, 0, false);
+        let v2 = mk_request::<i64>(2, 100, 10, 0, 0, true);
+        let p = Problem::new(
+            hs([v1, v2]),
+            hs([
+                ProblemEntry::Unassigned(RequestId::new(1)),
+                ProblemEntry::Unassigned(RequestId::new(2)),
+            ]),
+            SpaceLength::new(1_000),
+        )
+        .unwrap();
+
+        let sol = Solution::<i64, i64>::new(
+            &p,
+            [
+                Decision::Assign(Assignment::new(
+                    RequestId::new(1),
+                    SpacePosition::new(100),
+                    TimePoint::new(5),
+                )),
+                Decision::Drop(RequestId::new(2)),
+            ],
+        )
+        .unwrap();
+
+        match sol.decisions().get(&RequestId::new(1)).copied().unwrap() {
+            Decision::Assign(a) => {
+                assert_eq!(a.berthing_position(), SpacePosition::new(100));
+                assert_eq!(a.berthing_time(), TimePoint::new(5));
+            }
+            _ => panic!("v1 should be assigned"),
+        }
+
+        match sol.decisions().get(&RequestId::new(2)).copied().unwrap() {
+            Decision::Drop(id) => assert_eq!(id, RequestId::new(2)),
+            _ => panic!("v2 should be dropped"),
+        }
+
+        let stats = sol.stats();
+        assert_eq!(stats.total_waiting_time().value(), 5);
+        assert_eq!(stats.total_target_position_deviation().value(), 100);
+        assert_eq!(stats.total_dropped_requests(), 1);
+        assert_eq!(stats.total_cost().value(), 5 + 100 + 7);
+    }
+
+    #[test]
+    fn solution_new_err_overlap() {
+        let v1 = mk_request::<i64>(1, 200, 10, 0, 0, false);
+        let v2 = mk_request::<i64>(2, 200, 10, 0, 0, false);
+        let p = Problem::new(
+            hs([v1, v2]),
+            hs([
+                ProblemEntry::Unassigned(RequestId::new(1)),
+                ProblemEntry::Unassigned(RequestId::new(2)),
+            ]),
+            SpaceLength::new(600),
+        )
+        .unwrap();
+
+        let err = Solution::<i64, i64>::new(
+            &p,
+            [
+                Decision::Assign(Assignment::new(
+                    1.into(),
+                    SpacePosition::new(100),
+                    TimePoint::new(0),
+                )),
+                Decision::Assign(Assignment::new(
+                    2.into(),
+                    SpacePosition::new(150),
+                    TimePoint::new(5),
+                )),
+            ],
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, SolutionError::RequestOverlap(_)));
+    }
+
+    #[test]
+    fn solution_new_err_missing_decision() {
+        let v1 = mk_request::<i64>(1, 100, 10, 0, 0, false);
+        let p = Problem::new(
+            hs([v1]),
+            hs([ProblemEntry::Unassigned(1.into())]),
+            SpaceLength::new(1_000),
+        )
+        .unwrap();
+
+        let err = Solution::<i64, i64>::new(&p, []).unwrap_err();
+        assert!(matches!(err, SolutionError::MissingDecision(_)));
+    }
+
+    #[test]
+    fn solution_new_err_preassigned_changed() {
+        let v1 = mk_request::<i64>(1, 100, 10, 0, 100, false);
+        let a = Assignment::new(1.into(), SpacePosition::new(200), TimePoint::new(5));
+        let p = Problem::new(
+            hs([v1]),
+            hs([ProblemEntry::PreAssigned(a)]),
+            SpaceLength::new(1_000),
+        )
+        .unwrap();
+
+        let err = Solution::<i64, i64>::new(
+            &p,
+            [Decision::Assign(Assignment::new(
+                1.into(),
+                SpacePosition::new(220),
+                TimePoint::new(5),
+            ))],
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, SolutionError::PreassignmentChanged { .. }));
+    }
+
+    #[test]
+    fn solution_new_err_drop_not_droppable() {
+        let v1 = mk_request::<i64>(1, 100, 10, 0, 0, false);
+        let p = Problem::new(
+            hs([v1]),
+            hs([ProblemEntry::Unassigned(1.into())]),
+            SpaceLength::new(1_000),
+        )
+        .unwrap();
+
+        let err = Solution::<i64, i64>::new(&p, [Decision::Drop(1.into())]).unwrap_err();
+
+        assert!(matches!(err, SolutionError::DroppedNotDroppable(_)));
     }
 }

--- a/crates/dock-alloc-model/src/lib.rs
+++ b/crates/dock-alloc-model/src/lib.rs
@@ -19,7 +19,22 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#[allow(dead_code)]
+#![forbid(unsafe_code)]
+
+//! Unified domain model for the Berthing Allocation Problem (BAP).
+//!
+//! This module models **vessels** and **maintenance windows** uniformly as
+//! *occupants* of the quay in time–space, validates pre-assignments, and
+//! detects overlaps with a single sweep-line algorithm using half-open
+//! intervals in both time and space.
+//!
+//! Highlights
+//! - Self-documenting types and names (no cryptic `t0`, `x1`, etc.).
+//! - Unified `Occupant`, `OccupancyAssignment`, `OccupancyEntry`, `OccupancyRect`.
+//! - Clear, hand-written error types (no external derive macros).
+//! - Robust validation: quay bounds, arrival-time feasibility, maintenance feasible window.
+//! - Half-open semantics: adjacent in time/space is allowed; true overlap is rejected.
+
 use std::fmt::Display;
 use std::{
     cmp::Ordering,
@@ -34,20 +49,18 @@ use dock_alloc_core::domain::{
 };
 use num_traits::{PrimInt, Signed};
 
-/// Represents a unique identifier for a vessel.
+/// Identifier for a vessel.
 ///
-/// This identifier is used to track vessels in the system.
-/// It is a wrapper around a `u64` value, providing methods to create and access
-/// the identifier value.
+/// Newtype around `u64` to avoid accidental mix-ups with other integer IDs.
 ///
 /// # Examples
 ///
 /// ```
 /// use dock_alloc_model::VesselId;
-///
-/// let vessel_id = VesselId::new(12345);
-/// assert_eq!(vessel_id.value(), 12345);
+/// let vessel_id = VesselId::new(123);
+/// assert_eq!(vessel_id.value(), 123);
 /// ```
+#[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VesselId(u64);
 
@@ -66,7 +79,7 @@ impl VesselId {
     /// ```
     #[inline]
     pub const fn new(id: u64) -> Self {
-        VesselId(id)
+        Self(id)
     }
 
     /// Returns the underlying `u64` value of the `VesselId`.
@@ -88,47 +101,112 @@ impl VesselId {
 }
 
 impl Display for VesselId {
-    /// Formats the `VesselId` for display.
-    ///
-    /// This implementation provides a string representation of the `VesselId`
-    /// in the format `VesselId(value)`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::VesselId;
-    ///
-    /// let id = VesselId::new(42);
-    /// assert_eq!(format!("{}", id), "VesselId(42)");
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "VesselId({})", self.0)
     }
 }
 
 impl From<u64> for VesselId {
-    /// Converts a `u64` value into a `VesselId`.
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Identifier for a maintenance specification/window.
+///
+/// Newtype around `u64`.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::MaintenanceId;
+/// let maintenance_id = MaintenanceId::new(7);
+/// assert_eq!(maintenance_id.value(), 7);
+/// ```
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MaintenanceId(u64);
+
+impl MaintenanceId {
+    /// Creates a new `MaintenanceId` with the given identifier value.
     ///
-    /// This implementation allows for easy conversion from a `u64` to a `VesselId`.
+    /// This function creates a new `MaintenanceId` instance with the specified `u64` value.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::VesselId;
+    /// use dock_alloc_model::MaintenanceId;
     ///
-    /// let id: VesselId = 42.into();
-    /// assert_eq!(id.value(), 42);
+    /// let id = MaintenanceId::new(7);
+    /// assert_eq!(id.value(), 7);
     /// ```
-    fn from(value: u64) -> Self {
-        VesselId(value)
+    #[inline]
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the underlying `u64` value of the `MaintenanceId`.
+    ///
+    /// This function retrieves the `u64` value that the `MaintenanceId` wraps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dock_alloc_model::MaintenanceId;
+    ///
+    /// let id = MaintenanceId::new(7);
+    /// assert_eq!(id.value(), 7);
+    /// ```
+    #[inline]
+    pub const fn value(&self) -> u64 {
+        self.0
     }
 }
 
-/// Represents a vessel in the Berthing Allocation Problem.
+impl Display for MaintenanceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MaintenanceId({})", self.0)
+    }
+}
+
+impl From<u64> for MaintenanceId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// A vessel to be scheduled in the Berthing Allocation Problem.
 ///
-/// This struct encapsulates all the necessary information about a vessel,
-/// including its unique identifier, length, arrival time, processing duration,
-/// target berthing position, and associated costs.
+/// Vessels are unique by their [`VesselId`]; equality and hashing
+/// are therefore ID-based.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{Vessel, VesselId};
+/// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint, TimeInterval};
+///
+/// let vessel = Vessel::new(
+///     VesselId::new(1),
+///     SpaceLength::new(120),
+///     TimePoint::new(100),
+///     TimeDelta::new(20),
+///     SpacePosition::new(400),
+///     Cost::new(3),
+///     Cost::new(1),
+///     TimeInterval::new(TimePoint::new(100), TimePoint::new(200)),
+///     Cost::new(10000),
+/// );
+///
+/// assert_eq!(vessel.id(), VesselId::new(1));
+/// assert_eq!(vessel.length(), SpaceLength::new(120));
+/// assert_eq!(vessel.arrival_time(), TimePoint::new(100));
+/// assert_eq!(vessel.processing_duration(), TimeDelta::new(20));
+/// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(400));
+/// assert_eq!(vessel.cost_per_waiting_time().value(), 3);
+/// assert_eq!(vessel.cost_per_target_berthing_deviation().value(), 1);
+/// assert_eq!(vessel.drop_cost(), Cost::new(10000));
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct Vessel<TimeType = i64, CostType = i64>
 where
@@ -142,6 +220,8 @@ where
     target_berthing_position: SpacePosition,
     cost_per_waiting_time: Cost<CostType>,
     cost_per_target_berthing_deviation: Cost<CostType>,
+    feasible_time: TimeInterval<TimeType>,
+    drop_cost: Cost<CostType>,
 }
 
 impl<TimeType, CostType> PartialEq for Vessel<TimeType, CostType>
@@ -149,36 +229,6 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Compares two `Vessel` instances for equality based on their unique identifiers.
-    ///
-    /// This implementation checks if the `id` of one vessel is equal to the `id` of another vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// assert!(vessel1 == vessel2);
-    /// ```
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
@@ -197,44 +247,6 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Computes the hash of the `Vessel` based on its unique identifier.
-    ///
-    /// This implementation hashes the `id` of the vessel, allowing it to be used in hash-based collections.
-    ///
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::hash::{Hash, Hasher};
-    /// use std::collections::hash_map::DefaultHasher;
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// let mut h1 = DefaultHasher::new();
-    /// vessel1.hash(&mut h1);
-    /// let mut h2 = DefaultHasher::new();
-    /// vessel2.hash(&mut h2);
-    /// assert_eq!(h1.finish(), h2.finish());
-    /// ```
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
@@ -246,45 +258,9 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Compares two `Vessel` instances for ordering based on their unique identifiers.
-    ///
-    /// This implementation allows for partial ordering of vessels, primarily based on their `id`.
-    ///
-    /// # Note
-    ///
-    /// You might expect ordering based on the arrival time or other attributes,
-    /// but this implementation only considers the `id` for simplicity. You need
-    /// to implement additional logic if you want to compare vessels based on other attributes.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(2),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// assert!(vessel1 < vessel2);
-    /// ```
     #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.id.cmp(&other.id))
     }
 }
 
@@ -293,44 +269,8 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Compares two `Vessel` instances for total ordering based on their unique identifiers.
-    ///
-    /// This implementation allows for total ordering of vessels, primarily based on their `id`.
-    ///
-    /// # Note
-    ///
-    /// You might expect ordering based on the arrival time or other attributes,
-    /// but this implementation only considers the `id` for simplicity. You need
-    /// to implement additional logic if you want to compare vessels based on other attributes.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessel1 = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// let vessel2 = Vessel::new(
-    ///     VesselId::new(2),
-    ///     SpaceLength::new(200),
-    ///     TimePoint::new(3), // Example timestamp
-    ///     TimeDelta::new(2), // Example duration in seconds
-    ///     SpacePosition::new(1),
-    ///     Cost::new(300), // Example cost per waiting time
-    ///     Cost::new(500), // Example cost per target berthing deviation
-    /// );
-    /// assert!(vessel1 < vessel2);
-    /// ```
     #[inline]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         self.id.cmp(&other.id)
     }
 }
@@ -340,33 +280,27 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Creates a new `Vessel` instance with the specified parameters.
+    /// Creates a new vessel.
     ///
-    /// This function initializes a `Vessel` with its unique identifier, length,
-    /// arrival time, processing duration, target berthing position, and cost parameters.
+    /// This function constructs a new `Vessel` instance with the specified parameters.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
+    /// # use dock_alloc_model::{Vessel, VesselId};
+    /// # use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint, TimeInterval};
     /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     VesselId::new(5),
+    ///     SpaceLength::new(90),
+    ///     TimePoint::new(10),
+    ///     TimeDelta::new(4),
+    ///     SpacePosition::new(200),
+    ///     Cost::new(2),
+    ///     Cost::new(1),
+    ///     TimeInterval::new(TimePoint::new(10), TimePoint::new(50)),
+    ///     Cost::new(100),
     /// );
-    /// assert_eq!(vessel.id(), VesselId::new(1));
-    /// assert_eq!(vessel.length(), SpaceLength::new(100));
-    /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
-    /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
-    /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
-    /// assert_eq!(vessel.cost_per_waiting_time(), Cost::new(10));
-    /// assert_eq!(vessel.cost_per_target_berthing_deviation(), Cost::new(5));
+    /// assert_eq!(vessel.id(), VesselId::new(5));
     /// ```
     #[inline]
     pub fn new(
@@ -377,8 +311,11 @@ where
         target_berthing_position: SpacePosition,
         cost_per_waiting_time: Cost<CostType>,
         cost_per_target_berthing_deviation: Cost<CostType>,
+        // NEW:
+        feasible_time: TimeInterval<TimeType>,
+        drop_cost: Cost<CostType>,
     ) -> Self {
-        Vessel {
+        Self {
             id,
             length,
             arrival_time,
@@ -386,6 +323,9 @@ where
             target_berthing_position,
             cost_per_waiting_time,
             cost_per_target_berthing_deviation,
+            // NEW:
+            feasible_time,
+            drop_cost,
         }
     }
 
@@ -397,16 +337,18 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.id(), VesselId::new(1));
     /// ```
@@ -423,16 +365,18 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.length(), SpaceLength::new(100));
     /// ```
@@ -449,16 +393,18 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.arrival_time(), TimePoint::new(1622547800));
     /// ```
@@ -475,16 +421,18 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.processing_duration(), TimeDelta::new(3600));
     /// ```
@@ -501,16 +449,18 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.target_berthing_position(), SpacePosition::new(50));
     /// ```
@@ -527,16 +477,18 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.cost_per_waiting_time().value(), 10);
     /// ```
@@ -553,22 +505,82 @@ where
     ///
     /// ```
     /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint, TimeInterval};
     ///
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
+    ///     TimePoint::new(1622547800),
+    ///     TimeDelta::new(3600),
     ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     Cost::new(10),
+    ///     Cost::new(5),
+    ///     TimeInterval::new(TimePoint::new(1622547800), TimePoint::new(1622547800 + 7200)),
+    ///     Cost::new(1000),
     /// );
     /// assert_eq!(vessel.cost_per_target_berthing_deviation().value(), 5);
     /// ```
     #[inline]
     pub fn cost_per_target_berthing_deviation(&self) -> Cost<CostType> {
         self.cost_per_target_berthing_deviation
+    }
+
+    /// Time window in which the vessel must be processed.
+    ///
+    /// Returns the `TimeInterval` during which the vessel's processing must occur.
+    /// The interval is half-open, `[start, end)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{Vessel, VesselId};
+    /// # use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint, TimeInterval};
+    /// let feasible_time = TimeInterval::new(TimePoint::new(10), TimePoint::new(50));
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(0),
+    ///     TimeDelta::new(10),
+    ///     SpacePosition::new(0),
+    ///     Cost::new(5),
+    ///     Cost::new(1),
+    ///     feasible_time,
+    ///     Cost::new(1000),
+    /// );
+    /// assert_eq!(vessel.feasible_time(), feasible_time);
+    /// ```
+    #[inline]
+    pub fn feasible_time(&self) -> TimeInterval<TimeType> {
+        self.feasible_time
+    }
+
+    /// Cost paid if the vessel is dropped (not served).
+    ///
+    /// Returns the penalty `Cost` incurred if the scheduling algorithm decides
+    /// not to assign a berth to this vessel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{Vessel, VesselId};
+    /// # use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint, TimeInterval};
+    /// let drop_cost = Cost::new(5000);
+    /// let vessel = Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(0),
+    ///     TimeDelta::new(10),
+    ///     SpacePosition::new(0),
+    ///     Cost::new(5),
+    ///     Cost::new(1),
+    ///     TimeInterval::new(TimePoint::new(0), TimePoint::new(100)),
+    ///     drop_cost,
+    /// );
+    /// assert_eq!(vessel.drop_cost(), drop_cost);
+    /// ```
+    #[inline]
+    pub fn drop_cost(&self) -> Cost<CostType> {
+        self.drop_cost
     }
 }
 
@@ -577,40 +589,39 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed + TryFrom<TimeType>,
 {
-    /// Calculates the cost incurred by the vessel for waiting time.
+    /// Computes the waiting cost for a given waiting duration.
     ///
-    /// This function computes the cost based on the waiting time provided as a `TimeDelta`.
-    /// It multiplies the waiting time by the cost per waiting time to determine the total cost.
+    /// This multiplies the vessel's `cost_per_waiting_time` by the provided duration.
     ///
     /// # Panics
     ///
-    /// This function will panic if the waiting time does not fit into the `CostType` and a conversion
-    /// would result in an overflow or underflow.
+    /// Panics if the waiting duration cannot be converted to `CostType`
+    /// (overflow/underflow).
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
+    /// # use dock_alloc_model::{Vessel, VesselId};
+    /// # use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint, TimeInterval};
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     TimePoint::new(0),
+    ///     TimeDelta::new(10),
+    ///     SpacePosition::new(0),
+    ///     Cost::new(5),
+    ///     Cost::new(1),
+    ///     TimeInterval::new(TimePoint::new(0), TimePoint::new(100)),
+    ///     Cost::new(1000),
     /// );
-    /// let waiting_time = TimeDelta::new(2); // Example waiting time in seconds
-    /// let cost = vessel.waiting_cost(waiting_time);
-    /// assert_eq!(cost.value(), 20); // 10 * 2
+    /// let cost = vessel.waiting_cost(TimeDelta::new(3));
+    /// assert_eq!(cost.value(), 15);
     /// ```
     #[inline]
-    pub fn waiting_cost(&self, waiting_time: TimeDelta<TimeType>) -> Cost<CostType> {
-        let scalar: CostType = CostType::try_from(waiting_time.value())
+    pub fn waiting_cost(&self, waiting_duration: TimeDelta<TimeType>) -> Cost<CostType> {
+        let scalar: CostType = CostType::try_from(waiting_duration.value())
             .ok()
-            .expect("waiting time does not fit in CostType");
+            .expect("waiting duration does not fit in CostType");
         self.cost_per_waiting_time * scalar
     }
 }
@@ -620,35 +631,33 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed + TryFrom<usize>,
 {
-    /// Calculates the cost incurred by the vessel for deviations from the target berthing position.
+    /// Computes the cost of deviating from the target berthing position.
     ///
-    /// This function computes the cost based on the deviation from the target berthing position
-    /// provided as a `SpaceLength`. It multiplies the deviation by the cost per target berthing deviation
-    /// to determine the total cost.
+    /// This multiplies the vessel's `cost_per_target_berthing_deviation` by the provided deviation.
     ///
     /// # Panics
     ///
-    /// This function will panic if the deviation does not fit into the `CostType` and a conversion
-    /// would result in an overflow or underflow.
+    /// Panics if the deviation length cannot be converted to `CostType`
+    /// (overflow/underflow).
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
+    /// # use dock_alloc_model::{Vessel, VesselId};
+    /// # use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint, TimeInterval};
     /// let vessel = Vessel::new(
     ///     VesselId::new(1),
     ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
+    ///     TimePoint::new(0),
+    ///     TimeDelta::new(10),
+    ///     SpacePosition::new(20),
+    ///     Cost::new(10),
+    ///     Cost::new(2),
+    ///     TimeInterval::new(TimePoint::new(0), TimePoint::new(100)),
+    ///     Cost::new(1000),
     /// );
-    /// let deviation = SpaceLength::new(3); // Example deviation in length
-    /// let cost = vessel.target_berthing_deviation_cost(deviation);
-    /// assert_eq!(cost.value(), 15); // 5 * 3
+    /// let cost = vessel.target_berthing_deviation_cost(SpaceLength::new(7));
+    /// assert_eq!(cost.value(), 14);
     /// ```
     #[inline]
     pub fn target_berthing_deviation_cost(&self, deviation: SpaceLength) -> Cost<CostType> {
@@ -664,316 +673,523 @@ where
     TimeType: PrimInt + Signed + Display,
     CostType: PrimInt + Signed + Display,
 {
-    /// Formats the `Vessel` for display.
-    ///
-    /// This implementation provides a string representation of the `Vessel`
-    /// including its identifier, length, arrival time, processing duration,
-    /// target berthing position, and cost parameters.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessel = Vessel::new(
-    ///     VesselId::new(1),
-    ///     SpaceLength::new(100),
-    ///     TimePoint::new(1622547800), // Example timestamp
-    ///     TimeDelta::new(3600), // Example duration in seconds
-    ///     SpacePosition::new(50),
-    ///     Cost::new(10), // Example cost per waiting time
-    ///     Cost::new(5), // Example cost per target berthing deviation
-    /// );
-    /// println!("{}", vessel);
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Vessel(id: {}, length: {}, arrival_time: {}, processing_duration: {}, target_berthing_position: {}, cost_per_waiting_time: {}, cost_per_target_berthing_deviation: {})",
+            "Vessel(id: {}, length: {}, arrival_time: {}, processing_duration: {}, target_berthing_position: {}, cost_per_waiting_time: {}, cost_per_target_berthing_deviation: {}, feasible_time: {}, drop_cost: {})",
             self.id,
             self.length,
             self.arrival_time,
             self.processing_duration,
             self.target_berthing_position,
             self.cost_per_waiting_time,
-            self.cost_per_target_berthing_deviation
+            self.cost_per_target_berthing_deviation,
+            self.feasible_time,
+            self.drop_cost
         )
     }
 }
 
-/// Represents an assignment of a vessel to a berthing position and time.
+/// Fixed-position maintenance window specification.
 ///
-/// This struct encapsulates the details of a vessel's assignment, including the vessel itself,
-/// the berthing position along the quay, and the berthing time.
+/// A maintenance specification *fixes* the quay position and length and
+/// the processing duration; only the start time is to be chosen within
+/// a feasible time interval.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_model::{Assignment, VesselId};
-/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+/// use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+/// use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
 ///
-/// let assignment = Assignment::new(
-///     VesselId::new(1),
-///     SpacePosition::new(100),
-///     TimePoint::new(1622547800)
+/// let spec = MaintenanceSpec::new(
+///     MaintenanceId::new(10),
+///     SpacePosition::new(300),
+///     SpaceLength::new(50),
+///     TimeDelta::new(4),
+///     TimeInterval::new(TimePoint::new(100), TimePoint::new(200)),
 /// );
-/// assert_eq!(assignment.vessel_id(), VesselId::new(1));
-/// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
-/// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+///
+/// assert_eq!(spec.id(), MaintenanceId::new(10));
+/// assert_eq!(spec.position(), SpacePosition::new(300));
+/// assert_eq!(spec.length(), SpaceLength::new(50));
+/// assert_eq!(spec.duration(), TimeDelta::new(4));
+/// assert_eq!(spec.feasible_time().start(), TimePoint::new(100));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Assignment<TimeType = i64>
-where
-    TimeType: PrimInt + Signed,
-{
-    vessel_id: VesselId,
-    berthing_position: SpacePosition,
-    berthing_time: TimePoint<TimeType>,
+#[derive(Debug, Clone, Copy)]
+pub struct MaintenanceSpec<TimeType: PrimInt + Signed> {
+    id: MaintenanceId,
+    position: SpacePosition,
+    length: SpaceLength,
+    duration: TimeDelta<TimeType>,
+    feasible_time: TimeInterval<TimeType>,
 }
 
-impl<TimeType> Assignment<TimeType>
-where
-    TimeType: PrimInt + Signed,
-{
-    /// Creates a new `Assignment` instance with the specified parameters.
+impl<TimeType: PrimInt + Signed> MaintenanceSpec<TimeType> {
+    /// Creates a new maintenance specification.
     ///
-    /// This function initializes an `Assignment` with the vessel's unique identifier,
-    /// the berthing position along the quay, and the berthing time.
+    /// Constructs a `MaintenanceSpec` with a fixed position, length, duration,
+    /// and a time window within which it can be scheduled.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
+    /// # use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
+    /// let spec = MaintenanceSpec::new(
+    ///     MaintenanceId::new(1),
     ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
+    ///     SpaceLength::new(20),
+    ///     TimeDelta::new(5),
+    ///     TimeInterval::new(TimePoint::new(10), TimePoint::new(30)),
     /// );
-    /// assert_eq!(assignment.vessel_id(), VesselId::new(1));
-    /// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
-    /// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+    /// assert_eq!(spec.id().value(), 1);
     /// ```
     #[inline]
     pub fn new(
-        vessel_id: VesselId,
-        berthing_position: SpacePosition,
-        berthing_time: TimePoint<TimeType>,
+        id: MaintenanceId,
+        position: SpacePosition,
+        length: SpaceLength,
+        duration: TimeDelta<TimeType>,
+        feasible_time: TimeInterval<TimeType>,
     ) -> Self {
-        Assignment {
-            vessel_id,
-            berthing_position,
-            berthing_time,
+        Self {
+            id,
+            position,
+            length,
+            duration,
+            feasible_time,
         }
     }
 
-    /// Returns the unique identifier of the vessel associated with the assignment.
+    /// The maintenance identifier.
     ///
-    /// This function retrieves the `VesselId` of the vessel that has
-    /// been assigned to a specific berthing position and time.
+    /// Returns the unique `MaintenanceId` for this specification.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// assert_eq!(assignment.vessel_id(), VesselId::new(1));
+    /// # use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
+    /// let spec = MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(0), SpaceLength::new(0), TimeDelta::new(0), TimeInterval::new(TimePoint::new(0), TimePoint::new(1)));
+    /// assert_eq!(spec.id(), MaintenanceId::new(1));
     /// ```
     #[inline]
-    pub fn vessel_id(&self) -> VesselId {
-        self.vessel_id
+    pub fn id(&self) -> MaintenanceId {
+        self.id
     }
-
-    /// Returns the berthing position of the vessel.
+    /// Fixed start position along the quay.
     ///
-    /// This function retrieves the `SpacePosition` along the
-    /// quay where the vessel is assigned to berth.
+    /// Returns the `SpacePosition` where the maintenance window begins.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// assert_eq!(assignment.berthing_position(), SpacePosition::new(100));
+    /// # use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
+    /// let spec = MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(150), SpaceLength::new(0), TimeDelta::new(0), TimeInterval::new(TimePoint::new(0), TimePoint::new(1)));
+    /// assert_eq!(spec.position(), SpacePosition::new(150));
     /// ```
     #[inline]
-    pub fn berthing_position(&self) -> SpacePosition {
-        self.berthing_position
+    pub fn position(&self) -> SpacePosition {
+        self.position
     }
-
-    /// Returns the berthing time of the vessel.
+    /// Fixed spatial length on the quay.
     ///
-    /// This function retrieves the `TimePoint` representing
-    /// when the vessel is scheduled to berth.
+    /// Returns the `SpaceLength` occupied by the maintenance.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// assert_eq!(assignment.berthing_time(), TimePoint::new(1622547800));
+    /// # use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
+    /// let spec = MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(0), SpaceLength::new(75), TimeDelta::new(0), TimeInterval::new(TimePoint::new(0), TimePoint::new(1)));
+    /// assert_eq!(spec.length(), SpaceLength::new(75));
     /// ```
     #[inline]
-    pub fn berthing_time(&self) -> TimePoint<TimeType> {
-        self.berthing_time
+    pub fn length(&self) -> SpaceLength {
+        self.length
+    }
+    /// Fixed processing duration.
+    ///
+    /// Returns the `TimeDelta` indicating how long the maintenance takes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
+    /// let spec = MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(0), SpaceLength::new(0), TimeDelta::new(8), TimeInterval::new(TimePoint::new(0), TimePoint::new(10)));
+    /// assert_eq!(spec.duration(), TimeDelta::new(8));
+    /// ```
+    #[inline]
+    pub fn duration(&self) -> TimeDelta<TimeType> {
+        self.duration
+    }
+    /// Feasible time interval for scheduling the maintenance.
+    ///
+    /// Returns the `TimeInterval` in which the maintenance must be scheduled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceId, MaintenanceSpec};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition, TimeDelta, TimeInterval, TimePoint};
+    /// let interval = TimeInterval::new(TimePoint::new(100), TimePoint::new(200));
+    /// let spec = MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(0), SpaceLength::new(0), TimeDelta::new(0), interval);
+    /// assert_eq!(spec.feasible_time(), interval);
+    /// ```
+    #[inline]
+    pub fn feasible_time(&self) -> TimeInterval<TimeType> {
+        self.feasible_time
     }
 }
 
-impl<TimeType> Display for Assignment<TimeType>
-where
-    TimeType: PrimInt + Signed + Display,
-{
-    /// Formats the `Assignment` for display.
-    ///
-    /// This implementation provides a string representation of the `Assignment`
-    /// including the vessel identifier, berthing position, and berthing time.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let assignment = Assignment::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// );
-    /// println!("{}", assignment);
-    /// ```
+impl<TimeType: PrimInt + Signed + Display> Display for MaintenanceSpec<TimeType> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Assignment(vessel_id: {}, berthing_position: {}, berthing_time: {})",
-            self.vessel_id, self.berthing_position, self.berthing_time
+            "MaintenanceSpec(id: {}, position: {}, length: {}, duration: {}, feasible_time: {})",
+            self.id, self.position, self.length, self.duration, self.feasible_time
         )
     }
 }
 
-/// Represents an entry in the Berthing Allocation Problem.
+impl<TimeType: PrimInt + Signed> PartialEq for MaintenanceSpec<TimeType> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<TimeType: PrimInt + Signed> Eq for MaintenanceSpec<TimeType> {}
+
+impl<TimeType: PrimInt + Signed> Hash for MaintenanceSpec<TimeType> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl<TimeType: PrimInt + Signed> PartialOrd for MaintenanceSpec<TimeType> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.id.cmp(&other.id))
+    }
+}
+
+impl<TimeType: PrimInt + Signed> Ord for MaintenanceSpec<TimeType> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+/// A unified occupant of the quay: either a vessel or a maintenance window.
 ///
-/// This enum distinguishes between vessels that are unassigned and those
-/// that have been pre-assigned specific berthing positions and times.
+/// This enum allows treating both vessels and maintenance tasks uniformly as entities
+/// that occupy a time-space rectangle on the quay. This simplifies validation logic,
+/// such as overlap detection.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_model::{ProblemEntry, Assignment, VesselId};
-/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-///
-/// let unassigned: ProblemEntry<i64> = ProblemEntry::Unassigned(VesselId::new(1));
-/// let pre_assigned: ProblemEntry<i64> = ProblemEntry::PreAssigned(Assignment::new(
-///     VesselId::new(2),
-///     SpacePosition::new(100),
-///     TimePoint::new(1622547800)
-/// ));
-/// assert!(matches!(unassigned, ProblemEntry::Unassigned(_)));
-/// assert!(matches!(pre_assigned, ProblemEntry::PreAssigned(_)));
+/// use dock_alloc_model::{Occupant, VesselId, MaintenanceId};
+/// assert_eq!(format!("{}", Occupant::Vessel(VesselId::new(1))), "Vessel(VesselId(1))");
+/// assert_eq!(format!("{}", Occupant::Maintenance(MaintenanceId::new(2))), "Maintenance(MaintenanceId(2))");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum ProblemEntry<TimeType = i64>
-where
-    TimeType: PrimInt + Signed,
-{
-    /// A vessel that has not been assigned a berthing position or time.
-    ///
-    /// This variant holds the `VesselId` of the unassigned vessel.
-    /// The solver can decide freely where and when to berth this vessel.
-    Unassigned(VesselId),
-
-    /// A vessel that has been pre-assigned a specific berthing position and time.
-    ///
-    /// This variant holds an `Assignment` struct containing the details of the pre-assignment.
-    /// The solver must respect this assignment and cannot change it.
-    PreAssigned(Assignment<TimeType>),
+pub enum Occupant {
+    /// A vessel occupant, identified by its `VesselId`.
+    Vessel(VesselId),
+    /// A maintenance occupant, identified by its `MaintenanceId`.
+    Maintenance(MaintenanceId),
 }
 
-impl<TimeType> Display for ProblemEntry<TimeType>
-where
-    TimeType: PrimInt + Signed + Display,
-{
-    /// Formats the `ProblemEntry` for display.
+impl Display for Occupant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Occupant::Vessel(id) => write!(f, "Vessel({})", id),
+            Occupant::Maintenance(id) => write!(f, "Maintenance({})", id),
+        }
+    }
+}
+
+/// A time–space rectangle occupied on the quay by a specific [`Occupant`].
+///
+/// Rectangles use **half-open** intervals in both time and space:
+/// `[start, end)`. This allows adjacency without overlap, simplifying collision checks.
+/// For example, one task can end at time `t` and another can start at the same time `t`
+/// without being considered an overlap.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{OccupancyRect, Occupant, VesselId};
+/// use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+///
+/// let rect = OccupancyRect::new(
+///     Occupant::Vessel(VesselId::new(1)),
+///     TimeInterval::new(TimePoint::new(0), TimePoint::new(10)),
+///     SpaceInterval::new(SpacePosition::new(100), SpacePosition::new(150)),
+/// );
+///
+/// assert_eq!(rect.occupant(), &Occupant::Vessel(VesselId::new(1)));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OccupancyRect<TimeType: PrimInt + Signed> {
+    occupant: Occupant,
+    time_interval: TimeInterval<TimeType>,
+    space_interval: SpaceInterval,
+}
+
+impl<TimeType: PrimInt + Signed> OccupancyRect<TimeType> {
+    /// Creates a new occupancy rectangle.
     ///
-    /// This implementation provides a string representation of the `ProblemEntry`
-    /// indicating whether it is an unassigned vessel or a pre-assigned vessel with its details.
+    /// Constructs an `OccupancyRect` from an occupant and its time and space intervals.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{ProblemEntry, Assignment, VesselId};
-    /// use dock_alloc_core::domain::{SpacePosition, TimePoint};
-    ///
-    /// let unassigned: ProblemEntry<i64> = ProblemEntry::Unassigned(VesselId::new(1));
-    /// let pre_assigned: ProblemEntry<i64> = ProblemEntry::PreAssigned(Assignment::new(
-    ///     VesselId::new(2),
-    ///     SpacePosition::new(100),
-    ///     TimePoint::new(1622547800)
-    /// ));
-    /// println!("{}", unassigned);
-    /// println!("{}", pre_assigned);
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let rect = OccupancyRect::new(
+    ///     Occupant::Vessel(VesselId::new(42)),
+    ///     TimeInterval::new(TimePoint::new(10), TimePoint::new(20)),
+    ///     SpaceInterval::new(SpacePosition::new(50), SpacePosition::new(150)),
+    /// );
+    /// assert!(matches!(rect.occupant(), Occupant::Vessel(_)));
     /// ```
+    #[inline]
+    pub fn new(
+        occupant: Occupant,
+        time_interval: TimeInterval<TimeType>,
+        space_interval: SpaceInterval,
+    ) -> Self {
+        Self {
+            occupant,
+            time_interval,
+            space_interval,
+        }
+    }
+
+    /// Returns the occupant.
+    ///
+    /// Retrieves a reference to the `Occupant` associated with this rectangle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let rect = OccupancyRect::new(Occupant::Vessel(VesselId::new(1)), TimeInterval::new(TimePoint::new(0), TimePoint::new(1)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(1)));
+    /// assert_eq!(*rect.occupant(), Occupant::Vessel(VesselId::new(1)));
+    /// ```
+    #[inline]
+    pub fn occupant(&self) -> &Occupant {
+        &self.occupant
+    }
+    /// Returns the half-open time interval.
+    ///
+    /// Retrieves a reference to the `TimeInterval` `[start, end)` for this occupancy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let interval = TimeInterval::new(TimePoint::new(5), TimePoint::new(15));
+    /// let rect = OccupancyRect::new(Occupant::Vessel(VesselId::new(1)), interval, SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(1)));
+    /// assert_eq!(*rect.time_interval(), interval);
+    /// ```
+    #[inline]
+    pub fn time_interval(&self) -> &TimeInterval<TimeType> {
+        &self.time_interval
+    }
+    /// Returns the half-open space interval.
+    ///
+    /// Retrieves a reference to the `SpaceInterval` `[start, end)` for this occupancy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let interval = SpaceInterval::new(SpacePosition::new(50), SpacePosition::new(150));
+    /// let rect = OccupancyRect::new(Occupant::Vessel(VesselId::new(1)), TimeInterval::new(TimePoint::new(0), TimePoint::new(1)), interval);
+    /// assert_eq!(*rect.space_interval(), interval);
+    /// ```
+    #[inline]
+    pub fn space_interval(&self) -> &SpaceInterval {
+        &self.space_interval
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for OccupancyRect<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OccupancyRect(occupant: {}, time_interval: {}, space_interval: {})",
+            self.occupant, self.time_interval, self.space_interval
+        )
+    }
+}
+
+/// A unified pre-assignment of an occupant.
+///
+/// This enum represents a fixed assignment for either a vessel or a maintenance window.
+/// - Vessels: provide berthing position and start time.
+/// - Maintenance: provide the start time; position/length come from the spec.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{OccupancyAssignment, VesselId, MaintenanceId};
+/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
+///
+/// let v = OccupancyAssignment::Vessel {
+///     vessel_id: VesselId::new(3),
+///     berthing_position: SpacePosition::new(500),
+///     berthing_time: TimePoint::new(20),
+/// };
+///
+/// let m = OccupancyAssignment::Maintenance {
+///     id: MaintenanceId::new(7),
+///     start_time: TimePoint::new(120),
+/// };
+///
+/// assert!(matches!(v, OccupancyAssignment::Vessel{..}));
+/// assert!(matches!(m, OccupancyAssignment::Maintenance{..}));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum OccupancyAssignment<TimeType: PrimInt + Signed> {
+    /// Vessel pre-assignment.
+    Vessel {
+        /// Vessel identifier.
+        vessel_id: VesselId,
+        /// Quay position where the vessel’s bow (start) is berthed.
+        berthing_position: SpacePosition,
+        /// Start time of processing.
+        berthing_time: TimePoint<TimeType>,
+    },
+    /// Maintenance pre-assignment.
+    Maintenance {
+        /// Maintenance identifier (references a spec).
+        id: MaintenanceId,
+        /// Start time of the maintenance processing.
+        start_time: TimePoint<TimeType>,
+    },
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for OccupancyAssignment<TimeType> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProblemEntry::Unassigned(vessel_id) => {
-                write!(f, "Unassigned(vessel_id: {})", vessel_id)
-            }
-            ProblemEntry::PreAssigned(assignment) => {
-                write!(f, "PreAssigned({})", assignment)
+            Self::Vessel {
+                vessel_id,
+                berthing_position,
+                berthing_time,
+            } => write!(
+                f,
+                "VesselAssignment(vessel_id: {}, position: {}, time: {})",
+                vessel_id, berthing_position, berthing_time
+            ),
+            Self::Maintenance { id, start_time } => {
+                write!(
+                    f,
+                    "MaintenanceAssignment(id: {}, start_time: {})",
+                    id, start_time
+                )
             }
         }
     }
 }
 
-/// Error indicating that a vessel with a specified ID is missing.
+/// Unified problem entry: either an occupant still to be scheduled or a fixed pre-assignment.
 ///
-/// This error is used to signal that a required vessel could not be found
-/// in the context of a berthing allocation problem.
+/// This allows a problem instance to contain a mix of tasks that need scheduling
+/// (`Unassigned`) and tasks that have already been placed on the schedule (`PreAssigned`).
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_model::MissingVesselError;
+/// use dock_alloc_model::{OccupancyEntry, OccupancyAssignment, Occupant, VesselId, MaintenanceId};
+/// use dock_alloc_core::domain::{SpacePosition, TimePoint};
 ///
-/// let error = MissingVesselError::new(1.into());
-/// assert_eq!(error.vessel_id(), 1.into());
+/// let unassigned_vessel: OccupancyEntry<i64> = OccupancyEntry::Unassigned(Occupant::Vessel(VesselId::new(1)));
+/// let fixed = OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel{
+///     vessel_id: VesselId::new(1),
+///     berthing_position: SpacePosition::new(100),
+///     berthing_time: TimePoint::new(10),
+/// });
+///
+/// assert!(matches!(unassigned_vessel, OccupancyEntry::Unassigned(_)));
+/// assert!(matches!(fixed, OccupancyEntry::PreAssigned(_)));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum OccupancyEntry<TimeType: PrimInt + Signed> {
+    /// Occupant that is not yet assigned and needs to be scheduled.
+    Unassigned(Occupant),
+    /// Occupant that already has a fixed assignment on the quay.
+    PreAssigned(OccupancyAssignment<TimeType>),
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for OccupancyEntry<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unassigned(o) => write!(f, "Unassigned({})", o),
+            Self::PreAssigned(a) => write!(f, "PreAssigned({})", a),
+        }
+    }
+}
+
+/* ---------------------------- Error Types ----------------------------- */
+
+/// Error: a referenced vessel is missing from the problem’s vessel set.
+///
+/// This error occurs during problem validation if a pre-assignment or other
+/// entry refers to a `VesselId` that does not correspond to any vessel
+/// defined in the problem's set of vessels.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{MissingVesselError, VesselId};
+/// let err = MissingVesselError::new(VesselId::new(9));
+/// assert_eq!(err.vessel_id(), VesselId::new(9));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct MissingVesselError(VesselId);
 
-impl Display for MissingVesselError {
-    /// Formats the `MissingVesselError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the ID of the missing vessel.
+impl MissingVesselError {
+    /// Creates a new error for the given vessel id.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error = MissingVesselError::new(VesselId::new(1).into());
-    /// println!("{}", error);
+    /// # use dock_alloc_model::{MissingVesselError, VesselId};
+    /// let err = MissingVesselError::new(VesselId::new(99));
+    /// assert_eq!(err.vessel_id().value(), 99);
     /// ```
+    #[inline]
+    pub fn new(vessel_id: VesselId) -> Self {
+        Self(vessel_id)
+    }
+    /// Returns the missing vessel id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MissingVesselError, VesselId};
+    /// let err = MissingVesselError::new(VesselId::new(99));
+    /// assert_eq!(err.vessel_id(), VesselId::new(99));
+    /// ```
+    #[inline]
+    pub fn vessel_id(&self) -> VesselId {
+        self.0
+    }
+}
+
+impl Display for MissingVesselError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Missing vessel with ID: {}", self.0)
     }
@@ -982,570 +1198,732 @@ impl Display for MissingVesselError {
 impl std::error::Error for MissingVesselError {}
 
 impl From<VesselId> for MissingVesselError {
-    /// Converts a `VesselId` into a `MissingVesselError`.
-    ///
-    /// This implementation allows for easy creation of a `MissingVesselError`
-    /// from a `VesselId`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error: MissingVesselError = VesselId::new(1).into();
-    /// assert_eq!(error.vessel_id(), 1.into());
-    /// ```
-    #[inline]
-    fn from(vessel_id: VesselId) -> Self {
-        MissingVesselError(vessel_id)
+    fn from(value: VesselId) -> Self {
+        Self(value)
     }
 }
 
-impl MissingVesselError {
-    /// Creates a new `MissingVesselError` with the specified vessel ID.
-    ///
-    /// This function initializes a `MissingVesselError` with the given `VesselId`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error = MissingVesselError::new(VesselId::new(1));
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// ```
-    #[inline]
-    pub fn new(vessel_id: VesselId) -> Self {
-        MissingVesselError(vessel_id)
-    }
-
-    /// Returns the unique identifier of the missing vessel.
-    ///
-    /// This function retrieves the `VesselId` associated with the missing vessel.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselId, MissingVesselError};
-    ///
-    /// let error = MissingVesselError::new(VesselId::new(1));
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// ```
-    #[inline]
-    pub fn vessel_id(&self) -> VesselId {
-        self.0
-    }
-}
-
-/// Error indicating that a vessel is out of placed in a way that exceeds the quay length.
+/// Error: a pre-assigned vessel is scheduled outside its feasible time window.
 ///
-/// This error is used to signal that a vessel's end position exceeds the quay length.
+/// This error occurs if a vessel's processing interval `[start, end)` is not
+/// fully contained within its defined `feasible_time` interval.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-/// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
+/// use dock_alloc_model::{VesselId, VesselOutsideFeasibleTimeError};
+/// use dock_alloc_core::domain::{TimeInterval, TimePoint};
 ///
-/// let error = VesselOutOfBoundsError::new(
+/// let err = VesselOutsideFeasibleTimeError::new(
 ///     VesselId::new(1),
-///     SpacePosition::new(1500),
-///     SpaceLength::new(1000)
+///     TimePoint::new(5),
+///     TimePoint::new(15),
+///     TimeInterval::new(TimePoint::new(10), TimePoint::new(20)),
 /// );
-/// assert_eq!(error.vessel_id(), VesselId::new(1));
-/// assert_eq!(error.end_pos(), SpacePosition::new(1500));
-/// assert_eq!(error.quay_length(), SpaceLength::new(1000));
+/// assert_eq!(err.vessel_id(), VesselId::new(1));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct VesselOutOfBoundsError {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VesselOutsideFeasibleTimeError<TimeType: PrimInt + Signed> {
     vessel_id: VesselId,
-    end_pos: SpacePosition,
-    quay_length: SpaceLength,
+    assigned_start_time: TimePoint<TimeType>,
+    assigned_end_time: TimePoint<TimeType>,
+    feasible_time: TimeInterval<TimeType>,
 }
 
-impl Display for VesselOutOfBoundsError {
-    /// Formats the `VesselOutOfBoundsError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the vessel ID, end position, and quay length.
+impl<TimeType: PrimInt + Signed> VesselOutsideFeasibleTimeError<TimeType> {
+    /// Creates a new `VesselOutsideFeasibleTimeError`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
+    /// # use dock_alloc_model::{VesselId, VesselOutsideFeasibleTimeError};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let error = VesselOutsideFeasibleTimeError::new(
     ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
+    ///     TimePoint::new(0),
+    ///     TimePoint::new(10),
+    ///     TimeInterval::new(TimePoint::new(5), TimePoint::new(15)),
     /// );
-    /// println!("{}", error);
+    /// assert_eq!(error.vessel_id().value(), 1);
     /// ```
+    #[inline]
+    pub fn new(
+        vessel_id: VesselId,
+        assigned_start_time: TimePoint<TimeType>,
+        assigned_end_time: TimePoint<TimeType>,
+        feasible_time: TimeInterval<TimeType>,
+    ) -> Self {
+        Self {
+            vessel_id,
+            assigned_start_time,
+            assigned_end_time,
+            feasible_time,
+        }
+    }
+    /// The ID of the vessel that was assigned out of its feasible time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{VesselId, VesselOutsideFeasibleTimeError};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let error = VesselOutsideFeasibleTimeError::new(VesselId::new(5), TimePoint::new(0), TimePoint::new(10), TimeInterval::new(TimePoint::new(5), TimePoint::new(15)));
+    /// assert_eq!(error.vessel_id(), VesselId::new(5));
+    /// ```
+    #[inline]
+    pub fn vessel_id(&self) -> VesselId {
+        self.vessel_id
+    }
+    /// The assigned start time of the vessel's processing.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{VesselId, VesselOutsideFeasibleTimeError};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let error = VesselOutsideFeasibleTimeError::new(VesselId::new(1), TimePoint::new(0), TimePoint::new(10), TimeInterval::new(TimePoint::new(5), TimePoint::new(15)));
+    /// assert_eq!(error.assigned_start_time(), TimePoint::new(0));
+    /// ```
+    #[inline]
+    pub fn assigned_start_time(&self) -> TimePoint<TimeType> {
+        self.assigned_start_time
+    }
+    /// The calculated end time of the vessel's processing.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{VesselId, VesselOutsideFeasibleTimeError};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let error = VesselOutsideFeasibleTimeError::new(VesselId::new(1), TimePoint::new(0), TimePoint::new(10), TimeInterval::new(TimePoint::new(5), TimePoint::new(15)));
+    /// assert_eq!(error.assigned_end_time(), TimePoint::new(10));
+    /// ```
+    #[inline]
+    pub fn assigned_end_time(&self) -> TimePoint<TimeType> {
+        self.assigned_end_time
+    }
+    /// The feasible time window for the vessel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{VesselId, VesselOutsideFeasibleTimeError};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let feasible = TimeInterval::new(TimePoint::new(5), TimePoint::new(15));
+    /// let error = VesselOutsideFeasibleTimeError::new(VesselId::new(1), TimePoint::new(0), TimePoint::new(10), feasible);
+    /// assert_eq!(error.feasible_time(), feasible);
+    /// ```
+    #[inline]
+    pub fn feasible_time(&self) -> TimeInterval<TimeType> {
+        self.feasible_time
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for VesselOutsideFeasibleTimeError<TimeType> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Vessel with ID {} is out of bounds: end position {} exceeds quay length {}",
-            self.vessel_id, self.end_pos, self.quay_length
+            "Vessel {} assigned [{}, {}) outside feasible {}",
+            self.vessel_id, self.assigned_start_time, self.assigned_end_time, self.feasible_time
         )
     }
 }
 
-impl std::error::Error for VesselOutOfBoundsError {}
+impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error
+    for VesselOutsideFeasibleTimeError<TimeType>
+{
+}
 
-impl VesselOutOfBoundsError {
-    /// Creates a new `VesselOutOfBoundsError` with the specified parameters.
-    ///
-    /// This function initializes a `VesselOutOfBoundsError` with the vessel's unique identifier,
-    /// the end position, and the quay length.
+/// Error: a referenced maintenance specification is missing.
+///
+/// This error occurs if a pre-assignment refers to a `MaintenanceId` that
+/// does not correspond to any defined `MaintenanceSpec`.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{MissingMaintenanceError, MaintenanceId};
+/// let err = MissingMaintenanceError::new(MaintenanceId::new(2));
+/// assert_eq!(err.maintenance_id(), MaintenanceId::new(2));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MissingMaintenanceError(MaintenanceId);
+
+impl MissingMaintenanceError {
+    /// Creates a new error for the given maintenance id.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
-    /// assert_eq!(error.end_pos(), SpacePosition::new(1500));
-    /// assert_eq!(error.quay_length(), SpaceLength::new(1000));
+    /// # use dock_alloc_model::{MissingMaintenanceError, MaintenanceId};
+    /// let err = MissingMaintenanceError::new(MaintenanceId::new(42));
+    /// assert_eq!(err.maintenance_id().value(), 42);
     /// ```
     #[inline]
-    pub fn new(vessel_id: VesselId, end_pos: SpacePosition, quay_length: SpaceLength) -> Self {
-        VesselOutOfBoundsError {
-            vessel_id,
-            end_pos,
+    pub fn new(maintenance_id: MaintenanceId) -> Self {
+        Self(maintenance_id)
+    }
+    /// Returns the missing maintenance id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MissingMaintenanceError, MaintenanceId};
+    /// let err = MissingMaintenanceError::new(MaintenanceId::new(42));
+    /// assert_eq!(err.maintenance_id(), MaintenanceId::new(42));
+    /// ```
+    #[inline]
+    pub fn maintenance_id(&self) -> MaintenanceId {
+        self.0
+    }
+}
+
+impl Display for MissingMaintenanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Missing maintenance spec with ID: {}", self.0)
+    }
+}
+
+impl std::error::Error for MissingMaintenanceError {}
+
+/// Error: an occupant would extend beyond the end of the quay.
+///
+/// This validation error occurs if an occupant's placement results in its
+/// end position exceeding the total length of the quay.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{Occupant, OccupantOutOfBoundsError, VesselId};
+/// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
+///
+/// let err = OccupantOutOfBoundsError::new(
+///     Occupant::Vessel(VesselId::new(1)),
+///     SpacePosition::new(1200),
+///     SpaceLength::new(1000),
+/// );
+/// assert_eq!(err.quay_length(), SpaceLength::new(1000));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OccupantOutOfBoundsError {
+    occupant: Occupant,
+    end_position: SpacePosition,
+    quay_length: SpaceLength,
+}
+
+impl OccupantOutOfBoundsError {
+    /// Creates a new out-of-bounds error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{Occupant, OccupantOutOfBoundsError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition};
+    /// let err = OccupantOutOfBoundsError::new(Occupant::Vessel(VesselId::new(1)), SpacePosition::new(1001), SpaceLength::new(1000));
+    /// assert_eq!(err.occupant(), Occupant::Vessel(VesselId::new(1)));
+    /// ```
+    #[inline]
+    pub fn new(occupant: Occupant, end_position: SpacePosition, quay_length: SpaceLength) -> Self {
+        Self {
+            occupant,
+            end_position,
             quay_length,
         }
     }
-
-    /// Returns the unique identifier of the vessel associated with the error.
-    ///
-    /// This function retrieves the `VesselId` of the vessel that is out of bounds.
+    /// The offending occupant.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.vessel_id(), VesselId::new(1));
+    /// # use dock_alloc_model::{Occupant, OccupantOutOfBoundsError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition};
+    /// let occupant = Occupant::Vessel(VesselId::new(1));
+    /// let err = OccupantOutOfBoundsError::new(occupant, SpacePosition::new(1001), SpaceLength::new(1000));
+    /// assert_eq!(err.occupant(), occupant);
     /// ```
-    pub fn vessel_id(&self) -> VesselId {
-        self.vessel_id
+    #[inline]
+    pub fn occupant(&self) -> Occupant {
+        self.occupant
     }
-
-    /// Returns the end position of the vessel that caused the error.
-    ///
-    /// This function retrieves the `SpacePosition` representing the end position of the vessel.
+    /// The computed end position that exceeded the quay.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.end_pos(), SpacePosition::new(1500));
+    /// # use dock_alloc_model::{Occupant, OccupantOutOfBoundsError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition};
+    /// let err = OccupantOutOfBoundsError::new(Occupant::Vessel(VesselId::new(1)), SpacePosition::new(1001), SpaceLength::new(1000));
+    /// assert_eq!(err.end_position(), SpacePosition::new(1001));
     /// ```
-    pub fn end_pos(&self) -> SpacePosition {
-        self.end_pos
+    #[inline]
+    pub fn end_position(&self) -> SpacePosition {
+        self.end_position
     }
-
-    /// Returns the quay length associated with the error.
-    ///
-    /// This function retrieves the `SpaceLength` representing the quay length.
+    /// The quay length.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselId, VesselOutOfBoundsError};
-    /// use dock_alloc_core::domain::{SpaceLength, SpacePosition};
-    ///
-    /// let error = VesselOutOfBoundsError::new(
-    ///     VesselId::new(1),
-    ///     SpacePosition::new(1500),
-    ///     SpaceLength::new(1000)
-    /// );
-    /// assert_eq!(error.quay_length(), SpaceLength::new(1000));
+    /// # use dock_alloc_model::{Occupant, OccupantOutOfBoundsError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceLength, SpacePosition};
+    /// let err = OccupantOutOfBoundsError::new(Occupant::Vessel(VesselId::new(1)), SpacePosition::new(1001), SpaceLength::new(1000));
+    /// assert_eq!(err.quay_length(), SpaceLength::new(1000));
     /// ```
+    #[inline]
     pub fn quay_length(&self) -> SpaceLength {
         self.quay_length
     }
 }
 
-/// Represents a rectangular region in the time-space domain for a vessel.
-///
-/// This struct encapsulates the vessel's identifier, the time interval during which
-/// the vessel occupies a position, and the spatial interval along the quay that the vessel occupies.
-///
-/// # Examples
-///
-/// ```
-/// use dock_alloc_model::{VesselRect, VesselId};
-/// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-///
-/// let vessel_rect = VesselRect::new(
-///     VesselId::new(1),
-///     TimeInterval::new(0.into(), 10.into()),
-///     SpaceInterval::new(100.into(), 200.into())
-/// );
-/// assert_eq!(vessel_rect.id(), VesselId::new(1));
-/// assert_eq!(vessel_rect.time_interval(), &TimeInterval::new(0.into(), 10.into()));
-/// assert_eq!(vessel_rect.space_interval(), &SpaceInterval::new(100.into(), 200.into()));
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct VesselRect<TimeType: PrimInt + Signed> {
-    id: VesselId,
-    time_interval: TimeInterval<TimeType>,
-    space_interval: SpaceInterval,
-}
-
-impl<TimeType: PrimInt + Signed> VesselRect<TimeType> {
-    /// Creates a new `VesselRect` instance with the specified parameters.
-    ///
-    /// This function initializes a `VesselRect` with the vessel's unique identifier,
-    /// the time interval during which the vessel occupies a position,
-    /// and the spatial interval along the quay that the vessel occupies.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// assert_eq!(vessel_rect.id(), VesselId::new(1));
-    /// assert_eq!(vessel_rect.time_interval(), &TimeInterval::new(0.into(), 10.into()));
-    /// assert_eq!(vessel_rect.space_interval(), &SpaceInterval::new(100.into(), 200.into()));
-    /// ```
-    pub fn new(
-        id: VesselId,
-        time_interval: TimeInterval<TimeType>,
-        space_interval: SpaceInterval,
-    ) -> Self {
-        Self {
-            id,
-            time_interval,
-            space_interval,
-        }
-    }
-
-    /// Returns the unique identifier of the vessel associated with the rectangle.
-    ///
-    /// This function retrieves the `VesselId` of the vessel that the rectangle represents.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// assert_eq!(vessel_rect.id(), VesselId::new(1));
-    /// ```
-    #[inline]
-    pub fn id(&self) -> VesselId {
-        self.id
-    }
-
-    /// Returns the time interval during which the vessel occupies a position.
-    ///
-    /// This function retrieves a reference to the `TimeInterval` representing
-    /// the time span of the vessel's occupation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// assert_eq!(vessel_rect.time_interval(), &TimeInterval::new(0.into(), 10.into()));
-    /// ```
-    pub fn time_interval(&self) -> &TimeInterval<TimeType> {
-        &self.time_interval
-    }
-
-    /// Returns the spatial interval along the quay that the vessel occupies.
-    ///
-    /// This function retrieves a reference to the `SpaceInterval` representing
-    /// the spatial span of the vessel's occupation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// assert_eq!(vessel_rect.space_interval(), &SpaceInterval::new(100.into(), 200.into()));
-    /// ```
-    pub fn space_interval(&self) -> &SpaceInterval {
-        &self.space_interval
-    }
-}
-
-impl<TimeType: PrimInt + Signed + Display> Display for VesselRect<TimeType> {
-    /// Formats the `VesselRect` for display.
-    ///
-    /// This implementation provides a string representation of the `VesselRect`
-    /// including the vessel identifier, time interval, and space interval.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    /// println!("{}", vessel_rect);
-    /// ```
+impl Display for OccupantOutOfBoundsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "VesselRect(id: {}, time_interval: {}, space_interval: {})",
-            self.id, self.time_interval, self.space_interval
+            "{} is out of bounds: end position {} exceeds quay length {}",
+            self.occupant, self.end_position, self.quay_length
         )
     }
 }
 
-/// Error indicating that two vessels overlap in their assigned time-space regions.
+impl std::error::Error for OccupantOutOfBoundsError {}
+
+/// Error: an early vessel assignment (before arrival).
 ///
-/// This error is used to signal that two vessels have been assigned overlapping
-/// time intervals and spatial intervals, which is not allowed in the berthing allocation problem.
+/// This error occurs if a vessel is assigned a berthing time that is earlier
+/// than its specified arrival time.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-/// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
+/// use dock_alloc_model::{VesselAssignedBeforeArrivalError, VesselId};
+/// use dock_alloc_core::domain::TimePoint;
 ///
-/// let vessel_rect_1 = VesselRect::new(
+/// let err = VesselAssignedBeforeArrivalError::new(
 ///     VesselId::new(1),
-///     TimeInterval::new(0.into(), 10.into()),
-///     SpaceInterval::new(100.into(), 200.into())
+///     TimePoint::new(5),
+///     TimePoint::new(10),
 /// );
-///
-/// let vessel_rect_2 = VesselRect::new(
-///     VesselId::new(2),
-///     TimeInterval::new(5.into(), 15.into()),
-///     SpaceInterval::new(150.into(), 250.into())
-/// );
-/// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-/// assert_eq!(error.a(), &vessel_rect_1);
-/// assert_eq!(error.b(), &vessel_rect_2);
+/// assert_eq!(err.vessel_id(), VesselId::new(1));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct VesselOverlapError<TimeType: PrimInt + Signed> {
-    a: VesselRect<TimeType>,
-    b: VesselRect<TimeType>,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VesselAssignedBeforeArrivalError<TimeType: PrimInt + Signed> {
+    vessel_id: VesselId,
+    assigned_start_time: TimePoint<TimeType>,
+    arrival_time: TimePoint<TimeType>,
 }
 
-impl<TimeType: PrimInt + Signed + Display> Display for VesselOverlapError<TimeType> {
-    /// Formats the `VesselOverlapError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the details of the two overlapping vessel rectangles.
+impl<TimeType: PrimInt + Signed> VesselAssignedBeforeArrivalError<TimeType> {
+    /// Creates a new error.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// println!("{}", error);
-    /// ```
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "VesselOverlapError between {} and {}", self.a, self.b)
-    }
-}
-
-impl<TimeType: PrimInt + Signed> VesselOverlapError<TimeType> {
-    /// Creates a new `VesselOverlapError` with the specified vessel rectangles.
-    ///
-    /// This function initializes a `VesselOverlapError` with the two overlapping `VesselRect` instances.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// assert_eq!(error.a(), &vessel_rect_1);
-    /// assert_eq!(error.b(), &vessel_rect_2);
+    /// # use dock_alloc_model::{VesselAssignedBeforeArrivalError, VesselId};
+    /// # use dock_alloc_core::domain::TimePoint;
+    /// let err = VesselAssignedBeforeArrivalError::new(VesselId::new(1), TimePoint::new(5), TimePoint::new(10));
+    /// assert_eq!(err.vessel_id().value(), 1);
     /// ```
     #[inline]
-    pub fn new(a: VesselRect<TimeType>, b: VesselRect<TimeType>) -> Self {
-        Self { a, b }
+    pub fn new(
+        vessel_id: VesselId,
+        assigned_start_time: TimePoint<TimeType>,
+        arrival_time: TimePoint<TimeType>,
+    ) -> Self {
+        Self {
+            vessel_id,
+            assigned_start_time,
+            arrival_time,
+        }
     }
-
-    /// Returns a reference to the first overlapping vessel rectangle.
-    ///
-    /// This function retrieves a reference to the first `VesselRect` involved in the overlap.
+    /// The vessel id.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// assert_eq!(error.a(), &vessel_rect_1);
+    /// # use dock_alloc_model::{VesselAssignedBeforeArrivalError, VesselId};
+    /// # use dock_alloc_core::domain::TimePoint;
+    /// let err = VesselAssignedBeforeArrivalError::new(VesselId::new(1), TimePoint::new(5), TimePoint::new(10));
+    /// assert_eq!(err.vessel_id(), VesselId::new(1));
     /// ```
-    pub fn a(&self) -> &VesselRect<TimeType> {
-        &self.a
+    #[inline]
+    pub fn vessel_id(&self) -> VesselId {
+        self.vessel_id
     }
-
-    /// Returns a reference to the second overlapping vessel rectangle.
-    ///
-    /// This function retrieves a reference to the second `VesselRect` involved in the overlap.
+    /// The invalid assigned start time.
     ///
     /// # Examples
     ///
     /// ```
-    /// use dock_alloc_model::{VesselRect, VesselId, VesselOverlapError};
-    /// use dock_alloc_core::domain::{TimeInterval, SpaceInterval};
-    ///
-    /// let vessel_rect_1 = VesselRect::new(
-    ///     VesselId::new(1),
-    ///     TimeInterval::new(0.into(), 10.into()),
-    ///     SpaceInterval::new(100.into(), 200.into())
-    /// );
-    ///
-    /// let vessel_rect_2 = VesselRect::new(
-    ///     VesselId::new(2),
-    ///     TimeInterval::new(5.into(), 15.into()),
-    ///     SpaceInterval::new(150.into(), 250.into())
-    /// );
-    /// let error = VesselOverlapError::new(vessel_rect_1, vessel_rect_2);
-    /// assert_eq!(error.b(), &vessel_rect_2);
+    /// # use dock_alloc_model::{VesselAssignedBeforeArrivalError, VesselId};
+    /// # use dock_alloc_core::domain::TimePoint;
+    /// let err = VesselAssignedBeforeArrivalError::new(VesselId::new(1), TimePoint::new(5), TimePoint::new(10));
+    /// assert_eq!(err.assigned_start_time(), TimePoint::new(5));
     /// ```
-    pub fn b(&self) -> &VesselRect<TimeType> {
-        &self.b
+    #[inline]
+    pub fn assigned_start_time(&self) -> TimePoint<TimeType> {
+        self.assigned_start_time
+    }
+    /// The required minimum (arrival) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{VesselAssignedBeforeArrivalError, VesselId};
+    /// # use dock_alloc_core::domain::TimePoint;
+    /// let err = VesselAssignedBeforeArrivalError::new(VesselId::new(1), TimePoint::new(5), TimePoint::new(10));
+    /// assert_eq!(err.arrival_time(), TimePoint::new(10));
+    /// ```
+    #[inline]
+    pub fn arrival_time(&self) -> TimePoint<TimeType> {
+        self.arrival_time
     }
 }
 
-/// Represents errors that can occur in the creation of a problem instance.
+impl<TimeType: PrimInt + Signed + Display> Display for VesselAssignedBeforeArrivalError<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Vessel {} assigned at {}, earlier than its arrival {}",
+            self.vessel_id, self.assigned_start_time, self.arrival_time
+        )
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error
+    for VesselAssignedBeforeArrivalError<TimeType>
+{
+}
+
+/// Error: a maintenance assignment outside its feasible window.
 ///
-/// This enum encapsulates various error types that may arise when defining
-/// a berthing allocation problem, such as missing vessels, vessels placed
-/// out of bounds, or overlapping vessels.
+/// This error occurs if a maintenance task's assigned time interval `[start, end)`
+/// is not fully contained within its `feasible_time` window.
 ///
 /// # Examples
 ///
 /// ```
-/// use dock_alloc_model::{ProblemError, MissingVesselError, VesselOutOfBoundsError, VesselOverlapError, VesselRect, VesselId};
+/// use dock_alloc_model::{MaintenanceOutsideFeasibleTimeError, MaintenanceId};
+/// use dock_alloc_core::domain::{TimeInterval, TimePoint};
 ///
-/// let missing_vessel_error: ProblemError<i64> = ProblemError::MissingVessel(MissingVesselError::new(VesselId::new(1)));
-/// println!("{}", missing_vessel_error);
+/// let err = MaintenanceOutsideFeasibleTimeError::new(
+///     MaintenanceId::new(7),
+///     TimePoint::new(0),
+///     TimePoint::new(5),
+///     TimeInterval::new(TimePoint::new(10), TimePoint::new(20)),
+/// );
+/// assert_eq!(err.maintenance_id(), MaintenanceId::new(7));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MaintenanceOutsideFeasibleTimeError<TimeType: PrimInt + Signed> {
+    maintenance_id: MaintenanceId,
+    assigned_start_time: TimePoint<TimeType>,
+    assigned_end_time: TimePoint<TimeType>,
+    feasible_time: TimeInterval<TimeType>,
+}
+
+impl<TimeType: PrimInt + Signed> MaintenanceOutsideFeasibleTimeError<TimeType> {
+    /// Creates a new error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceOutsideFeasibleTimeError, MaintenanceId};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let err = MaintenanceOutsideFeasibleTimeError::new(MaintenanceId::new(1), TimePoint::new(5), TimePoint::new(15), TimeInterval::new(TimePoint::new(10), TimePoint::new(20)));
+    /// assert_eq!(err.maintenance_id().value(), 1);
+    /// ```
+    #[inline]
+    pub fn new(
+        maintenance_id: MaintenanceId,
+        assigned_start_time: TimePoint<TimeType>,
+        assigned_end_time: TimePoint<TimeType>,
+        feasible_time: TimeInterval<TimeType>,
+    ) -> Self {
+        Self {
+            maintenance_id,
+            assigned_start_time,
+            assigned_end_time,
+            feasible_time,
+        }
+    }
+    /// The maintenance id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceOutsideFeasibleTimeError, MaintenanceId};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let err = MaintenanceOutsideFeasibleTimeError::new(MaintenanceId::new(1), TimePoint::new(5), TimePoint::new(15), TimeInterval::new(TimePoint::new(10), TimePoint::new(20)));
+    /// assert_eq!(err.maintenance_id(), MaintenanceId::new(1));
+    /// ```
+    #[inline]
+    pub fn maintenance_id(&self) -> MaintenanceId {
+        self.maintenance_id
+    }
+    /// Assigned start time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceOutsideFeasibleTimeError, MaintenanceId};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let err = MaintenanceOutsideFeasibleTimeError::new(MaintenanceId::new(1), TimePoint::new(5), TimePoint::new(15), TimeInterval::new(TimePoint::new(10), TimePoint::new(20)));
+    /// assert_eq!(err.assigned_start_time(), TimePoint::new(5));
+    /// ```
+    #[inline]
+    pub fn assigned_start_time(&self) -> TimePoint<TimeType> {
+        self.assigned_start_time
+    }
+    /// Assigned end time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceOutsideFeasibleTimeError, MaintenanceId};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let err = MaintenanceOutsideFeasibleTimeError::new(MaintenanceId::new(1), TimePoint::new(5), TimePoint::new(15), TimeInterval::new(TimePoint::new(10), TimePoint::new(20)));
+    /// assert_eq!(err.assigned_end_time(), TimePoint::new(15));
+    /// ```
+    #[inline]
+    pub fn assigned_end_time(&self) -> TimePoint<TimeType> {
+        self.assigned_end_time
+    }
+    /// Allowed feasible time interval.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{MaintenanceOutsideFeasibleTimeError, MaintenanceId};
+    /// # use dock_alloc_core::domain::{TimeInterval, TimePoint};
+    /// let interval = TimeInterval::new(TimePoint::new(10), TimePoint::new(20));
+    /// let err = MaintenanceOutsideFeasibleTimeError::new(MaintenanceId::new(1), TimePoint::new(5), TimePoint::new(15), interval);
+    /// assert_eq!(err.feasible_time(), interval);
+    /// ```
+    #[inline]
+    pub fn feasible_time(&self) -> TimeInterval<TimeType> {
+        self.feasible_time
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display
+    for MaintenanceOutsideFeasibleTimeError<TimeType>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Maintenance {} assigned [{}, {}) outside feasible {}",
+            self.maintenance_id,
+            self.assigned_start_time,
+            self.assigned_end_time,
+            self.feasible_time
+        )
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error
+    for MaintenanceOutsideFeasibleTimeError<TimeType>
+{
+}
+
+/// Error: overlap between two occupancy rectangles.
+///
+/// This error signals that two pre-assigned occupants have time and space
+/// intervals that overlap, which is not allowed. Adjacency is permitted due
+/// to half-open interval semantics.
+///
+/// # Examples
+///
+/// ```
+/// use dock_alloc_model::{OccupancyRect, Occupant, OccupancyOverlapError, VesselId};
+/// use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+///
+/// let a = OccupancyRect::new(
+///     Occupant::Vessel(VesselId::new(1)),
+///     TimeInterval::new(TimePoint::new(0), TimePoint::new(10)),
+///     SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(50)),
+/// );
+/// let b = OccupancyRect::new(
+///     Occupant::Vessel(VesselId::new(2)),
+///     TimeInterval::new(TimePoint::new(5), TimePoint::new(15)),
+///     SpaceInterval::new(SpacePosition::new(25), SpacePosition::new(75)),
+/// );
+/// let err = OccupancyOverlapError::new(a, b);
+/// assert_eq!(format!("{}", err).contains("overlap"), true);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OccupancyOverlapError<TimeType: PrimInt + Signed> {
+    rect_a: OccupancyRect<TimeType>,
+    rect_b: OccupancyRect<TimeType>,
+}
+
+impl<TimeType: PrimInt + Signed> OccupancyOverlapError<TimeType> {
+    /// Creates a new overlap error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, OccupancyOverlapError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let a = OccupancyRect::new(Occupant::Vessel(VesselId::new(1)), TimeInterval::new(TimePoint::new(0), TimePoint::new(10)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(10)));
+    /// let b = OccupancyRect::new(Occupant::Vessel(VesselId::new(2)), TimeInterval::new(TimePoint::new(5), TimePoint::new(15)), SpaceInterval::new(SpacePosition::new(5), SpacePosition::new(15)));
+    /// let err = OccupancyOverlapError::new(a, b);
+    /// assert_eq!(*err.a(), a);
+    /// assert_eq!(*err.b(), b);
+    /// ```
+    #[inline]
+    pub fn new(rect_a: OccupancyRect<TimeType>, rect_b: OccupancyRect<TimeType>) -> Self {
+        Self { rect_a, rect_b }
+    }
+    /// First rectangle involved.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, OccupancyOverlapError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let a = OccupancyRect::new(Occupant::Vessel(VesselId::new(1)), TimeInterval::new(TimePoint::new(0), TimePoint::new(10)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(10)));
+    /// let b = OccupancyRect::new(Occupant::Vessel(VesselId::new(2)), TimeInterval::new(TimePoint::new(5), TimePoint::new(15)), SpaceInterval::new(SpacePosition::new(5), SpacePosition::new(15)));
+    /// let err = OccupancyOverlapError::new(a, b);
+    /// assert_eq!(*err.a(), a);
+    /// ```
+    #[inline]
+    pub fn a(&self) -> &OccupancyRect<TimeType> {
+        &self.rect_a
+    }
+    /// Second rectangle involved.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dock_alloc_model::{OccupancyRect, Occupant, OccupancyOverlapError, VesselId};
+    /// # use dock_alloc_core::domain::{SpaceInterval, SpacePosition, TimeInterval, TimePoint};
+    /// let a = OccupancyRect::new(Occupant::Vessel(VesselId::new(1)), TimeInterval::new(TimePoint::new(0), TimePoint::new(10)), SpaceInterval::new(SpacePosition::new(0), SpacePosition::new(10)));
+    /// let b = OccupancyRect::new(Occupant::Vessel(VesselId::new(2)), TimeInterval::new(TimePoint::new(5), TimePoint::new(15)), SpaceInterval::new(SpacePosition::new(5), SpacePosition::new(15)));
+    /// let err = OccupancyOverlapError::new(a, b);
+    /// assert_eq!(*err.b(), b);
+    /// ```
+    #[inline]
+    pub fn b(&self) -> &OccupancyRect<TimeType> {
+        &self.rect_b
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display> Display for OccupancyOverlapError<TimeType> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Occupancy overlap between {} and {}",
+            self.rect_a, self.rect_b
+        )
+    }
+}
+
+impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error
+    for OccupancyOverlapError<TimeType>
+{
+}
+
+/// Errors that can occur when constructing a [`Problem`].
+///
+/// This enum aggregates all possible validation errors that can arise from
+/// creating a `Problem` instance, providing a single, comprehensive error type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ProblemError<TimeType: PrimInt + Signed> {
+    /// Pre-assignment referenced a vessel not present in `vessels`.
     MissingVessel(MissingVesselError),
-    VesselOutOfBounds(VesselOutOfBoundsError),
-    VesselOverlap(VesselOverlapError<TimeType>),
+    /// Pre-assignment referenced a maintenance spec not present in `maintenance_specs`.
+    MissingMaintenance(MissingMaintenanceError),
+    /// An occupant would exceed the quay bounds.
+    OccupantOutOfBounds(OccupantOutOfBoundsError),
+    /// Two pre-assigned rectangles overlap in time *and* space.
+    OccupancyOverlap(OccupancyOverlapError<TimeType>),
+    /// Vessel assigned before its arrival.
+    VesselAssignedBeforeArrival(VesselAssignedBeforeArrivalError<TimeType>),
+    /// Maintenance assigned outside its feasible time interval.
+    MaintenanceOutsideFeasibleTime(MaintenanceOutsideFeasibleTimeError<TimeType>),
+    /// Vessel assigned outside its feasible time interval.
+    VesselOutsideFeasibleTime(VesselOutsideFeasibleTimeError<TimeType>),
 }
 
 impl<TimeType: PrimInt + Signed + Display> Display for ProblemError<TimeType> {
-    /// Formats the `ProblemError` for display.
-    ///
-    /// This implementation provides a string representation of the error,
-    /// including the details of the specific error variant.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dock_alloc_model::{ProblemError, MissingVesselError, VesselId};
-    ///
-    /// let missing_vessel_error: ProblemError<i64> = ProblemError::MissingVessel(MissingVesselError::new(VesselId::new(1)));
-    /// println!("{}", missing_vessel_error);
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProblemError::MissingVessel(err) => write!(f, "{}", err),
-            ProblemError::VesselOutOfBounds(err) => write!(f, "{}", err),
-            ProblemError::VesselOverlap(err) => write!(f, "{}", err),
+            Self::MissingVessel(e) => write!(f, "{}", e),
+            Self::MissingMaintenance(e) => write!(f, "{}", e),
+            Self::OccupantOutOfBounds(e) => write!(f, "{}", e),
+            Self::OccupancyOverlap(e) => write!(f, "{}", e),
+            Self::VesselAssignedBeforeArrival(e) => write!(f, "{}", e),
+            Self::MaintenanceOutsideFeasibleTime(e) => write!(f, "{}", e),
+            Self::VesselOutsideFeasibleTime(e) => write!(f, "{}", e),
         }
     }
 }
 
 impl<TimeType: PrimInt + Signed + Display + Debug> std::error::Error for ProblemError<TimeType> {}
 
-/// Represents the Berthing Allocation Problem.
+/* ------------------------------ Problem ------------------------------- */
+
+/// The Berthing Allocation Problem instance.
 ///
-/// This struct encapsulates the problem's vessels and the quay length available for berthing.
-/// It provides methods to create a new problem instance, retrieve the quay length,
-/// and access the set of vessels involved in the problem.
+/// Holds the set of vessels, maintenance specifications, and problem entries
+/// (unassigned occupants or fixed pre-assignments), along with the quay length.
+///
+/// Construction validates all pre-assignments and rejects invalid instances with
+/// a [`ProblemError`].
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashSet;
+/// use dock_alloc_model::*;
+/// use dock_alloc_core::domain::*;
+///
+/// // Inputs
+/// let vessels: HashSet<_> = [
+///     Vessel::new(
+///         VesselId::new(1),
+///         SpaceLength::new(100),
+///         TimePoint::new(0),
+///         TimeDelta::new(10),
+///         SpacePosition::new(50),
+///         Cost::new(1),
+///         Cost::new(1),
+///         TimeInterval::new(TimePoint::new(0), TimePoint::new(100)),
+///         Cost::new(1000),
+///     ),
+/// ]
+/// .into_iter()
+/// .collect();
+///
+/// let maintenance_specs: HashSet<_> = [
+///     MaintenanceSpec::new(
+///         MaintenanceId::new(9),
+///         SpacePosition::new(300),
+///         SpaceLength::new(50),
+///         TimeDelta::new(5),
+///         TimeInterval::new(TimePoint::new(0), TimePoint::new(100)),
+///     ),
+/// ]
+/// .into_iter()
+/// .collect();
+///
+/// // Pre-assign one vessel; keep maintenance unassigned:
+/// let entries: HashSet<_> = [
+///     OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel{
+///         vessel_id: VesselId::new(1),
+///         berthing_position: SpacePosition::new(100),
+///         berthing_time: TimePoint::new(0),
+///     }),
+///     OccupancyEntry::Unassigned(Occupant::Maintenance(MaintenanceId::new(9))),
+/// ]
+/// .into_iter()
+/// .collect();
+///
+/// let problem = Problem::<i64, i64>::new(vessels, maintenance_specs, entries, SpaceLength::new(1_000)).unwrap();
+/// assert_eq!(problem.quay_length(), SpaceLength::new(1_000));
+/// assert_eq!(problem.vessel_len(), 1);
+/// assert_eq!(problem.maintenance_len(), 1);
+/// ```
 #[derive(Debug, Clone)]
 pub struct Problem<TimeType = i64, CostType = i64>
 where
@@ -1553,7 +1931,8 @@ where
     CostType: PrimInt + Signed,
 {
     vessels: HashSet<Vessel<TimeType, CostType>>,
-    entries: HashSet<ProblemEntry<TimeType>>,
+    maintenance_specs: HashSet<MaintenanceSpec<TimeType>>,
+    entries: HashSet<OccupancyEntry<TimeType>>,
     quay_length: SpaceLength,
 }
 
@@ -1562,404 +1941,431 @@ where
     TimeType: PrimInt + Signed,
     CostType: PrimInt + Signed,
 {
-    /// Creates a new `Problem` instance with the specified quay length.
+    /// Constructs a validated problem.
     ///
-    /// This function initializes a `Problem` with an empty set of vessels and the given quay length.
+    /// This validates all **pre-assigned** entries and ensures that
+    /// - referenced vessels/specs exist,
+    /// - vessels are not scheduled before arrival,
+    /// - maintenance is within its feasible interval,
+    /// - spatial end positions do not exceed the quay length,
+    /// - there is **no overlap** in time *and* space across all pre-assignments.
+    ///
+    /// Half-open semantics are used throughout: `[start, end)`.
+    ///
+    /// # Errors
+    /// Returns a [`ProblemError`] if any validation fails.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let vessels: HashSet<_> = [Vessel::new(
+    ///     VesselId::new(1),
+    ///     SpaceLength::new(100),
+    ///     TimePoint::new(0),
+    ///     TimeDelta::new(10),
+    ///     SpacePosition::new(50),
+    ///     Cost::new(1),
+    ///     Cost::new(1),
+    ///     TimeInterval::new(TimePoint::new(0), TimePoint::new(100)),
+    ///     Cost::new(1000),
+    /// )].into_iter().collect();
     ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
+    /// let maintenance_specs: HashSet<_> = [].into_iter().collect();
+    ///
+    /// let entries: HashSet<_> = [OccupancyEntry::PreAssigned(
+    ///     OccupancyAssignment::Vessel{
+    ///         vessel_id: VesselId::new(1),
+    ///         berthing_position: SpacePosition::new(100),
+    ///         berthing_time: TimePoint::new(0),
+    ///     }
+    /// )].into_iter().collect();
+    ///
+    /// let problem = Problem::<i64, i64>::new(vessels, maintenance_specs, entries, SpaceLength::new(1_000));
     /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
-    /// assert!(problem.vessels().is_empty());
-    /// assert!(problem.entries().is_empty());
     /// ```
-    #[inline]
     pub fn new(
         vessels: HashSet<Vessel<TimeType, CostType>>,
-        entries: HashSet<ProblemEntry<TimeType>>,
+        maintenance_specs: HashSet<MaintenanceSpec<TimeType>>,
+        entries: HashSet<OccupancyEntry<TimeType>>,
         quay_length: SpaceLength,
     ) -> Result<Self, ProblemError<TimeType>> {
-        let vmap: HashMap<VesselId, &Vessel<TimeType, CostType>> =
+        // Build lookup maps for fast validation.
+        let vessel_by_id: HashMap<VesselId, &Vessel<TimeType, CostType>> =
             vessels.iter().map(|v| (v.id(), v)).collect();
-        let quay_end: SpacePosition = SpacePosition::new(quay_length.value());
+        let maintenance_by_id: HashMap<MaintenanceId, &MaintenanceSpec<TimeType>> =
+            maintenance_specs.iter().map(|m| (m.id(), m)).collect();
 
-        let rects: Vec<VesselRect<TimeType>> = entries
-            .iter()
-            .filter_map(|e| match e {
-                ProblemEntry::PreAssigned(a) => Some(a),
-                _ => None,
-            })
-            .map(|a| {
-                let vid = a.vessel_id();
-                let v = *vmap
-                    .get(&vid)
-                    .ok_or_else(|| ProblemError::MissingVessel(MissingVesselError::new(vid)))?;
+        let quay_end_position: SpacePosition = SpacePosition::new(quay_length.value());
 
-                let t0: TimePoint<TimeType> = a.berthing_time();
-                let t1: TimePoint<TimeType> = t0 + v.processing_duration();
-                let time = TimeInterval::new(t0, t1);
+        // Build occupancy rectangles from pre-assigned entries.
+        let mut occupancy_rectangles: Vec<OccupancyRect<TimeType>> = Vec::new();
 
-                let x0: SpacePosition = a.berthing_position();
-                let x1: SpacePosition = x0 + v.length();
-                if x1 > quay_end {
-                    return Err(ProblemError::VesselOutOfBounds(
-                        VesselOutOfBoundsError::new(vid, x1, quay_length),
-                    ));
+        for entry in entries.iter() {
+            if let OccupancyEntry::PreAssigned(assignment) = entry {
+                match assignment {
+                    OccupancyAssignment::Vessel {
+                        vessel_id,
+                        berthing_position,
+                        berthing_time,
+                    } => {
+                        let vessel = *vessel_by_id.get(vessel_id).ok_or_else(|| {
+                            ProblemError::MissingVessel(MissingVesselError::new(*vessel_id))
+                        })?;
+
+                        // Enforce "not before arrival".
+                        if *berthing_time < vessel.arrival_time() {
+                            return Err(ProblemError::VesselAssignedBeforeArrival(
+                                VesselAssignedBeforeArrivalError::new(
+                                    *vessel_id,
+                                    *berthing_time,
+                                    vessel.arrival_time(),
+                                ),
+                            ));
+                        }
+
+                        let processing_start_time: TimePoint<TimeType> = *berthing_time;
+                        let processing_end_time: TimePoint<TimeType> =
+                            processing_start_time + vessel.processing_duration();
+
+                        let vessel_feasible = vessel.feasible_time();
+                        if processing_start_time < vessel_feasible.start()
+                            || processing_end_time > vessel_feasible.end()
+                        {
+                            return Err(ProblemError::VesselOutsideFeasibleTime(
+                                VesselOutsideFeasibleTimeError::new(
+                                    *vessel_id,
+                                    processing_start_time,
+                                    processing_end_time,
+                                    vessel_feasible,
+                                ),
+                            ));
+                        }
+
+                        let start_position: SpacePosition = *berthing_position;
+                        let end_position: SpacePosition = start_position + vessel.length();
+
+                        if end_position > quay_end_position {
+                            return Err(ProblemError::OccupantOutOfBounds(
+                                OccupantOutOfBoundsError::new(
+                                    Occupant::Vessel(*vessel_id),
+                                    end_position,
+                                    quay_length,
+                                ),
+                            ));
+                        }
+
+                        occupancy_rectangles.push(OccupancyRect::new(
+                            Occupant::Vessel(*vessel_id),
+                            TimeInterval::new(processing_start_time, processing_end_time),
+                            SpaceInterval::new(start_position, end_position),
+                        ));
+                    }
+                    OccupancyAssignment::Maintenance { id, start_time } => {
+                        let spec = *maintenance_by_id.get(id).ok_or_else(|| {
+                            ProblemError::MissingMaintenance(MissingMaintenanceError::new(*id))
+                        })?;
+
+                        let processing_start_time: TimePoint<TimeType> = *start_time;
+                        let processing_end_time: TimePoint<TimeType> =
+                            processing_start_time + spec.duration();
+
+                        // Must fit entirely in feasible interval.
+                        let feasible = spec.feasible_time();
+                        if processing_start_time < feasible.start()
+                            || processing_end_time > feasible.end()
+                        {
+                            return Err(ProblemError::MaintenanceOutsideFeasibleTime(
+                                MaintenanceOutsideFeasibleTimeError::new(
+                                    *id,
+                                    processing_start_time,
+                                    processing_end_time,
+                                    feasible,
+                                ),
+                            ));
+                        }
+
+                        let start_position: SpacePosition = spec.position();
+                        let end_position: SpacePosition = start_position + spec.length();
+                        if end_position > quay_end_position {
+                            return Err(ProblemError::OccupantOutOfBounds(
+                                OccupantOutOfBoundsError::new(
+                                    Occupant::Maintenance(*id),
+                                    end_position,
+                                    quay_length,
+                                ),
+                            ));
+                        }
+
+                        occupancy_rectangles.push(OccupancyRect::new(
+                            Occupant::Maintenance(*id),
+                            TimeInterval::new(processing_start_time, processing_end_time),
+                            SpaceInterval::new(start_position, end_position),
+                        ));
+                    }
                 }
-                let space = SpaceInterval::new(x0, x1);
+            }
+        }
 
-                Ok(VesselRect::new(vid, time, space))
-            })
-            .collect::<Result<_, ProblemError<TimeType>>>()?;
-
-        if rects.is_empty() {
-            return Ok(Problem {
+        // If there are no rectangles, overlap sweep is unnecessary.
+        if occupancy_rectangles.is_empty() {
+            return Ok(Self {
                 vessels,
+                maintenance_specs,
                 entries,
                 quay_length,
             });
         }
 
+        // Sweep-line over time with active set ordered by space start.
         #[derive(Clone, Copy, PartialEq, Eq)]
-        enum Kind {
+        enum BoundaryKind {
             Start,
             End,
         }
 
         #[derive(Clone, Copy)]
-        struct Event<T: PrimInt> {
-            t: TimePoint<T>,
-            kind: Kind,
-            idx: usize,
+        struct TimeBoundary<T: PrimInt + Signed> {
+            time: TimePoint<T>,
+            kind: BoundaryKind,
+            rectangle_index: usize,
         }
 
-        let mut events: Vec<Event<TimeType>> = rects
+        let mut time_boundaries: Vec<TimeBoundary<TimeType>> = occupancy_rectangles
             .iter()
             .enumerate()
-            .flat_map(|(i, r)| {
-                iter::once(Event {
-                    t: r.time_interval().start(),
-                    kind: Kind::Start,
-                    idx: i,
+            .flat_map(|(idx, rect)| {
+                iter::once(TimeBoundary {
+                    time: rect.time_interval().start(),
+                    kind: BoundaryKind::Start,
+                    rectangle_index: idx,
                 })
-                .chain(iter::once(Event {
-                    t: r.time_interval().end(),
-                    kind: Kind::End,
-                    idx: i,
+                .chain(iter::once(TimeBoundary {
+                    time: rect.time_interval().end(),
+                    kind: BoundaryKind::End,
+                    rectangle_index: idx,
                 }))
             })
             .collect();
 
-        events.sort_by(|a, b| {
-            a.t.cmp(&b.t).then_with(|| match (a.kind, b.kind) {
-                (Kind::End, Kind::Start) => Ordering::Less,
-                (Kind::Start, Kind::End) => Ordering::Greater,
+        // Sort time boundaries; at equal time, process End before Start (half-open).
+        time_boundaries.sort_by(|a, b| {
+            a.time.cmp(&b.time).then_with(|| match (a.kind, b.kind) {
+                (BoundaryKind::End, BoundaryKind::Start) => Ordering::Less,
+                (BoundaryKind::Start, BoundaryKind::End) => Ordering::Greater,
                 _ => Ordering::Equal,
             })
         });
-        let mut active: BTreeSet<(SpacePosition, usize)> = BTreeSet::new();
+
+        let mut active_by_space_start: BTreeSet<(SpacePosition, usize)> = BTreeSet::new();
 
         #[inline]
-        fn overlaps_ho(a: &SpaceInterval, b: &SpaceInterval) -> bool {
+        fn half_open_intervals_overlap(a: &SpaceInterval, b: &SpaceInterval) -> bool {
             a.start() < b.end() && b.start() < a.end()
         }
 
-        for e in events {
-            let r = rects[e.idx];
-            match e.kind {
-                Kind::Start => {
-                    let key = (r.space_interval().start(), e.idx);
+        for boundary in time_boundaries {
+            let rect = occupancy_rectangles[boundary.rectangle_index];
+            match boundary.kind {
+                BoundaryKind::Start => {
+                    let key = (rect.space_interval().start(), boundary.rectangle_index);
 
-                    if let Some(&(_, pidx)) = active.range(..key).next_back() {
-                        let pr = rects[pidx];
-                        if overlaps_ho(pr.space_interval(), r.space_interval()) {
-                            return Err(ProblemError::VesselOverlap(VesselOverlapError::new(
-                                pr, r,
-                            )));
-                        }
-                    }
-                    if let Some(&(_, sidx)) = active.range(key..).next() {
-                        let sr = rects[sidx];
-                        if overlaps_ho(sr.space_interval(), r.space_interval()) {
-                            return Err(ProblemError::VesselOverlap(VesselOverlapError::new(
-                                sr, r,
-                            )));
+                    // Check previous neighbor in space order, if any.
+                    if let Some(&(_, prev_idx)) = active_by_space_start.range(..key).next_back() {
+                        let prev_rect = occupancy_rectangles[prev_idx];
+                        if half_open_intervals_overlap(
+                            prev_rect.space_interval(),
+                            rect.space_interval(),
+                        ) {
+                            return Err(ProblemError::OccupancyOverlap(
+                                OccupancyOverlapError::new(prev_rect, rect),
+                            ));
                         }
                     }
 
-                    active.insert(key);
+                    // Check next neighbor in space order, if any.
+                    if let Some(&(_, next_idx)) = active_by_space_start.range(key..).next() {
+                        let next_rect = occupancy_rectangles[next_idx];
+                        if half_open_intervals_overlap(
+                            next_rect.space_interval(),
+                            rect.space_interval(),
+                        ) {
+                            return Err(ProblemError::OccupancyOverlap(
+                                OccupancyOverlapError::new(next_rect, rect),
+                            ));
+                        }
+                    }
+
+                    active_by_space_start.insert(key);
                 }
-                Kind::End => {
-                    active.remove(&(r.space_interval().start(), e.idx));
+                BoundaryKind::End => {
+                    active_by_space_start
+                        .remove(&(rect.space_interval().start(), boundary.rectangle_index));
                 }
             }
         }
 
-        Ok(Problem {
+        Ok(Self {
             vessels,
+            maintenance_specs,
             entries,
             quay_length,
         })
     }
 
-    /// Returns the quay length of the problem.
+    /// Returns the quay length.
     ///
-    /// This function retrieves the `SpaceLength` representing the length of the quay available for berthing vessels.
+    /// This is the total available space along the quay.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta , TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert_eq!(problem.quay_length(), SpaceLength::new(1000));
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let problem = Problem::<i64, i64>::new(HashSet::new(), HashSet::new(), HashSet::new(), SpaceLength::new(1200)).unwrap();
+    /// assert_eq!(problem.quay_length(), SpaceLength::new(1200));
     /// ```
     #[inline]
     pub fn quay_length(&self) -> SpaceLength {
         self.quay_length
     }
 
-    /// Returns a reference to the set of vessels in the problem.
+    /// Returns all vessels.
     ///
-    /// This function provides access to the `HashSet` of vessels, allowing iteration or inspection of the vessels involved in the problem.
+    /// Provides a reference to the `HashSet` of all `Vessel`s in the problem.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert!(problem.vessels().is_empty());
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let vessels = HashSet::from([Vessel::new(VesselId::new(1), SpaceLength::new(100), TimePoint::new(0), TimeDelta::new(10), SpacePosition::new(0), Cost::new(1), Cost::new(1), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)), Cost::new(1000))]);
+    /// let problem = Problem::new(vessels.clone(), HashSet::new(), HashSet::new(), SpaceLength::new(1000)).unwrap();
+    /// assert_eq!(*problem.vessels(), vessels);
     /// ```
     #[inline]
     pub fn vessels(&self) -> &HashSet<Vessel<TimeType, CostType>> {
         &self.vessels
     }
 
-    /// Returns a reference to the set of problem entries.
+    /// Returns all maintenance specifications.
     ///
-    /// This function provides access to the `HashSet` of problem entries,
-    /// allowing iteration or inspection of the entries involved in the problem.
+    /// Provides a reference to the `HashSet` of all `MaintenanceSpec`s in the problem.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{ProblemEntry, Problem, Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert!(problem.entries().is_empty());
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let specs = HashSet::from([MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(0), SpaceLength::new(50), TimeDelta::new(5), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)))]);
+    /// let problem: Problem<i64, i64> = Problem::new(HashSet::new(), specs.clone(), HashSet::new(), SpaceLength::new(1000)).unwrap();
+    /// assert_eq!(*problem.maintenance_specs(), specs);
     /// ```
     #[inline]
-    pub fn entries(&self) -> &HashSet<ProblemEntry<TimeType>> {
+    pub fn maintenance_specs(&self) -> &HashSet<MaintenanceSpec<TimeType>> {
+        &self.maintenance_specs
+    }
+
+    /// Returns all entries (unassigned or pre-assigned occupants).
+    ///
+    /// Provides a reference to the `HashSet` of all `OccupancyEntry`s, which represent
+    /// both schedulable tasks and fixed assignments.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let entries = HashSet::from([OccupancyEntry::Unassigned(Occupant::Vessel(VesselId::new(1)))]);
+    /// let vessels = HashSet::from([Vessel::new(VesselId::new(1), SpaceLength::new(100), TimePoint::new(0), TimeDelta::new(10), SpacePosition::new(0), Cost::new(1), Cost::new(1), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)), Cost::new(1000))]);
+    /// let problem = Problem::new(vessels, HashSet::new(), entries.clone(), SpaceLength::new(1000)).unwrap();
+    /// assert_eq!(*problem.entries(), entries);
+    /// ```
+    #[inline]
+    pub fn entries(&self) -> &HashSet<OccupancyEntry<TimeType>> {
         &self.entries
     }
 
-    /// Returns the number of vessels in the problem.
+    /// Number of vessels.
     ///
-    /// This function returns the count of vessels currently stored in the problem's vessel set.
+    /// Returns the total count of vessels defined in the problem.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::collections::HashSet;
-    /// use dock_alloc_model::{Problem, Vessel, VesselId};
-    /// use dock_alloc_core::domain::{Cost, SpaceLength, SpacePosition, TimeDelta, TimePoint};
-    ///
-    /// let vessels = HashSet::new();
-    /// let entries = HashSet::new();
-    /// let quay_length = SpaceLength::new(1000);
-    /// let problem = Problem::<i64, i64>::new(vessels, entries, quay_length);
-    /// assert!(problem.is_ok());
-    /// let problem = problem.unwrap();
-    /// assert_eq!(problem.vessel_len(), 0);
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let vessels = HashSet::from([Vessel::new(VesselId::new(1), SpaceLength::new(100), TimePoint::new(0), TimeDelta::new(10), SpacePosition::new(0), Cost::new(1), Cost::new(1), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)), Cost::new(1000))]);
+    /// let problem = Problem::new(vessels, HashSet::new(), HashSet::new(), SpaceLength::new(1000)).unwrap();
+    /// assert_eq!(problem.vessel_len(), 1);
     /// ```
     #[inline]
     pub fn vessel_len(&self) -> usize {
         self.vessels.len()
     }
+
+    /// Number of maintenance specifications.
+    ///
+    /// Returns the total count of maintenance specifications defined in the problem.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::collections::HashSet;
+    /// # use dock_alloc_model::*;
+    /// # use dock_alloc_core::domain::*;
+    /// let specs = HashSet::from([MaintenanceSpec::new(MaintenanceId::new(1), SpacePosition::new(0), SpaceLength::new(50), TimeDelta::new(5), TimeInterval::new(TimePoint::new(0), TimePoint::new(100)))]);
+    /// let problem: Problem<i64, i64> = Problem::new(HashSet::new(), specs, HashSet::new(), SpaceLength::new(1000)).unwrap();
+    /// assert_eq!(problem.maintenance_len(), 1);
+    /// ```
+    #[inline]
+    pub fn maintenance_len(&self) -> usize {
+        self.maintenance_specs.len()
+    }
 }
 
-/// Type alias for the Berthing Allocation Problem with default types for time and cost.
+/// Convenient type alias for the common `i64` time/cost instantiation.
 ///
-/// This alias simplifies the usage of the `Problem` struct by providing a default type for time and cost,
-/// which are both `i64`.
+/// This simplifies type signatures when working with the most common
+/// integer types for time and cost values in the problem domain.
 pub type BerthAllocationProblem = Problem<i64, i64>;
+
+/* ------------------------------- Tests -------------------------------- */
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_vessel_id_creation() {
-        let id = VesselId::new(42);
-        assert_eq!(id.value(), 42);
-    }
-
-    #[test]
-    fn test_vessel_id_display() {
-        let id = VesselId::new(42);
-        assert_eq!(format!("{}", id), "VesselId(42)");
-    }
-
-    #[test]
-    fn test_vessel_id_equality() {
-        let id1 = VesselId::new(42);
-        let id2 = VesselId::new(42);
-        assert_eq!(id1, id2);
-    }
-
-    #[test]
-    fn test_vessel_id_from_u64() {
-        let id: VesselId = 42.into();
-        assert_eq!(id.value(), 42);
-    }
-
-    #[test]
-    fn test_vessel_display() {
-        let vessel = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(1622547800),
-            TimeDelta::new(3600),
-            SpacePosition::new(50),
-            Cost::new(10),
-            Cost::new(5),
-        );
-        assert_eq!(
-            format!("{}", vessel),
-            "Vessel(id: VesselId(1), \
-            length: SpaceLength(100), \
-            arrival_time: TimePoint(1622547800), \
-            processing_duration: TimeDelta(3600), \
-            target_berthing_position: SpacePosition(50), \
-            cost_per_waiting_time: Cost(10), \
-            cost_per_target_berthing_deviation: Cost(5))"
-        );
-    }
-
-    #[test]
-    fn test_vessels_are_unique_by_id() {
-        let mut set = std::collections::HashSet::new();
-        let v1 = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(0),
-            TimeDelta::new(10),
-            SpacePosition::new(0),
-            Cost::new(1),
-            Cost::new(1),
-        );
-        let v2 = Vessel::new(
-            // same id, different fields
-            VesselId::new(1),
-            SpaceLength::new(200),
-            TimePoint::new(5),
-            TimeDelta::new(20),
-            SpacePosition::new(10),
-            Cost::new(2),
-            Cost::new(3),
-        );
-        set.insert(v1);
-        set.insert(v2);
-        assert_eq!(set.len(), 1);
-    }
-
-    #[test]
-    fn test_waiting_cost() {
-        let vessel = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(1622547800),
-            TimeDelta::new(3600),
-            SpacePosition::new(50),
-            Cost::new(10),
-            Cost::new(5),
-        );
-        let waiting_time = TimeDelta::new(2);
-        let cost = vessel.waiting_cost(waiting_time);
-        assert_eq!(cost.value(), 20); // 10 * 2
-    }
-
-    #[test]
-    fn test_target_berthing_deviation_cost() {
-        let vessel = Vessel::new(
-            VesselId::new(1),
-            SpaceLength::new(100),
-            TimePoint::new(1622547800),
-            TimeDelta::new(3600),
-            SpacePosition::new(50),
-            Cost::new(10),
-            Cost::new(5),
-        );
-        let deviation = SpaceLength::new(3);
-        let cost = vessel.target_berthing_deviation_cost(deviation);
-        assert_eq!(cost.value(), 15); // 5 * 3
-    }
-
-    #[test]
-    fn test_assignment_display() {
-        let assignment = Assignment::new(
-            VesselId::new(1),
-            SpacePosition::new(100),
-            TimePoint::new(1622547800),
-        );
-        assert_eq!(
-            format!("{}", assignment),
-            "Assignment(vessel_id: VesselId(1), \
-            berthing_position: SpacePosition(100), \
-            berthing_time: TimePoint(1622547800))"
-        );
-    }
-
-    fn v<T: PrimInt + Signed>(id: u64, len: usize, proc: T, arr: T, tgt: usize) -> Vessel<T, i64> {
+    fn vessel<T: PrimInt + Signed>(
+        id: u64,
+        length: usize,
+        processing: T,
+        arrival: T,
+        target_pos: usize,
+        feasible_interval: TimeInterval<T>,
+    ) -> Vessel<T, i64> {
         Vessel::new(
             VesselId::new(id),
-            SpaceLength::new(len),
-            TimePoint::new(arr),
-            TimeDelta::new(proc),
-            SpacePosition::new(tgt),
+            SpaceLength::new(length),
+            TimePoint::new(arrival),
+            TimeDelta::new(processing),
+            SpacePosition::new(target_pos),
             Cost::new(1),
+            Cost::new(1),
+            feasible_interval,
             Cost::new(1),
         )
     }
 
-    fn a<T: PrimInt + Signed>(id: u64, x0: usize, t0: T) -> ProblemEntry<T> {
-        ProblemEntry::PreAssigned(Assignment::new(
-            VesselId::new(id),
-            SpacePosition::new(x0),
-            TimePoint::new(t0),
-        ))
+    fn window<T: PrimInt + Signed>(start: T, end: T) -> TimeInterval<T> {
+        TimeInterval::new(TimePoint::new(start), TimePoint::new(end))
     }
 
     fn hs<T>(items: impl IntoIterator<Item = T>) -> HashSet<T>
@@ -1969,171 +2375,224 @@ mod tests {
         items.into_iter().collect()
     }
 
-    // ---------- tests ----------
-
-    /// No pre-assignments → always OK.
     #[test]
-    fn new_ok_no_entries() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0)]);
+    fn test_ok_no_preassignments() {
+        let vessels = hs([vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000))]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
         let entries = HashSet::new();
-        let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
+        let p = Problem::new(vessels, maints, entries, SpaceLength::new(1_000));
         assert!(p.is_ok());
     }
 
-    /// Single pre-assignment within quay bounds.
     #[test]
-    fn new_ok_single_preassignment_in_bounds() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0)]);
-        let entries = hs([a::<i64>(1, 50, 5)]);
+    fn test_ok_single_vessel_preassignment_in_bounds() {
+        let vessels = hs([vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000))]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+            vessel_id: VesselId::new(1),
+            berthing_position: SpacePosition::new(50),
+            berthing_time: TimePoint::new(0),
+        })]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
+        assert!(Problem::new(vessels, maints, entries, quay).is_ok());
     }
 
-    /// Pre-assigned vessel not present in vessels set → MissingVessel error.
     #[test]
-    fn new_err_missing_vessel() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0)]);
-        let entries = hs([a::<i64>(2, 50, 5)]); // vessel 2 does not exist
+    fn test_err_missing_vessel() {
+        let vessels = hs([vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000))]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+            vessel_id: VesselId::new(2), // not present
+            berthing_position: SpacePosition::new(50),
+            berthing_time: TimePoint::new(0),
+        })]);
         let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
+        let err = Problem::new(vessels, maints, entries, quay).unwrap_err();
         matches!(err, ProblemError::MissingVessel(_));
     }
 
-    /// End position (x0 + len) past quay_end → VesselOutOfBounds error.
     #[test]
-    fn new_err_out_of_bounds() {
-        let vessels = hs([v::<i64>(1, 200, 10, 0, 0)]);
-        // put the ship near the end so x1 > quay_end
-        let entries = hs([a::<i64>(1, 900, 0)]);
+    fn test_err_vessel_out_of_bounds() {
+        let vessels = hs([vessel::<i64>(1, 200, 10, 0, 0, window(0, 1_000))]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+            vessel_id: VesselId::new(1),
+            berthing_position: SpacePosition::new(900),
+            berthing_time: TimePoint::new(0),
+        })]);
         let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::VesselOutOfBounds(_));
+        let err = Problem::new(vessels, maints, entries, quay).unwrap_err();
+        matches!(err, ProblemError::OccupantOutOfBounds(_));
     }
 
-    /// Touching in time (t1 == t0') with same space overlap is allowed (half-open time).
     #[test]
-    fn new_ok_touching_in_time_same_space() {
-        // both length 100 at same x0
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // first: [t=0,10), second: starts at 10
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 100, 10)]);
-        let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
-    }
-
-    /// Touching in space (x1 == x0') during overlapping time is allowed (half-open space).
-    #[test]
-    fn new_ok_touching_in_space_same_time() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // same time window, adjacent in space: [100,200) and [200,300)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 200, 0)]);
-        let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
-    }
-
-    /// Overlap in both time and space → VesselOverlap error.
-    #[test]
-    fn new_err_overlap_in_time_and_space() {
-        let vessels = hs([v::<i64>(1, 150, 10, 0, 0), v::<i64>(2, 150, 10, 0, 0)]);
-        // same time window [0,10), space [100,250) vs [200,350) → overlap [200,250)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 200, 0)]);
-        let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::VesselOverlap(_));
-    }
-
-    /// Overlap in time only (space disjoint) → OK.
-    #[test]
-    fn new_ok_overlap_time_only() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // time overlaps, but space disjoint: [100,200) vs [300,400)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 300, 5)]);
-        let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
-    }
-
-    /// Overlap in space only (time disjoint) → OK.
-    #[test]
-    fn new_ok_overlap_space_only() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // same space [100,200) but time-disjoint: [0,10) and [10,20)
-        let entries = hs([a::<i64>(1, 100, 0), a::<i64>(2, 100, 10)]);
-        let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
-    }
-
-    /// End-before-Start tie handling: an assignment ending at t lets another
-    /// start at the same t without overlap.
-    #[test]
-    fn new_ok_end_before_start_tie() {
-        let vessels = hs([v::<i64>(1, 100, 10, 0, 0), v::<i64>(2, 100, 10, 0, 0)]);
-        // [0,10) then [10,20) at same space
-        let entries = hs([a::<i64>(1, 500, 0), a::<i64>(2, 500, 10)]);
-        let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
-    }
-
-    /// Neighbor check robustness: inserting a rect whose space lies between two active neighbors.
-    #[test]
-    fn new_ok_non_overlapping_middle_insert() {
-        // three ships length 50; middle fits exactly between neighbors
+    fn test_ok_touching_in_time_same_space() {
         let vessels = hs([
-            v::<i64>(1, 50, 10, 0, 0),
-            v::<i64>(2, 50, 10, 0, 0),
-            v::<i64>(3, 50, 10, 0, 0),
+            vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000)),
+            vessel::<i64>(2, 100, 10, 0, 0, window(0, 1_000)),
         ]);
-        // all overlap in time; spaces are [100,150), [150,200), [200,250)
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
         let entries = hs([
-            a::<i64>(1, 100, 0),
-            a::<i64>(2, 150, 0),
-            a::<i64>(3, 200, 0),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(1),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(0),
+            }),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(2),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(10),
+            }),
         ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
+        assert!(Problem::new(vessels, maints, entries, quay).is_ok());
     }
 
-    /// Overlap with equal x0: ensures we still detect overlap when two ships start at the same space start
-    /// and their times overlap.
     #[test]
-    fn new_err_equal_x0_overlapping_time() {
-        let vessels = hs([v::<i64>(1, 80, 10, 0, 0), v::<i64>(2, 80, 10, 0, 0)]);
-        // same x0, time windows overlap → overlap in space and time
-        let entries = hs([a::<i64>(1, 300, 0), a::<i64>(2, 300, 5)]);
-        let quay = SpaceLength::new(1_000);
-        let err = Problem::new(vessels, entries, quay).unwrap_err();
-        matches!(err, ProblemError::VesselOverlap(_));
-    }
-
-    /// Many non-overlapping assignments in shuffled order (stress ordering & sorting).
-    #[test]
-    fn new_ok_many_nonoverlapping_shuffled() {
+    fn test_ok_touching_in_space_same_time() {
         let vessels = hs([
-            v::<i64>(1, 60, 7, 0, 0),
-            v::<i64>(2, 60, 7, 0, 0),
-            v::<i64>(3, 60, 7, 0, 0),
-            v::<i64>(4, 60, 7, 0, 0),
+            vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000)),
+            vessel::<i64>(2, 100, 10, 0, 0, window(0, 1_000)),
         ]);
-        // Shuffle events across time and space but keep disjoint in at least one dimension pairwise.
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
         let entries = hs([
-            // time [0,7), space [0,60)
-            a::<i64>(1, 0, 0),
-            // time [5,12) but space disjoint: [120,180)
-            a::<i64>(2, 120, 5),
-            // time [12,19), same space as #1 (OK — time disjoint)
-            a::<i64>(3, 0, 12),
-            // time [10,17), space touches #2: [180,240) (OK — space touching)
-            a::<i64>(4, 180, 10),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(1),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(0),
+            }),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(2),
+                berthing_position: SpacePosition::new(200),
+                berthing_time: TimePoint::new(0),
+            }),
         ]);
         let quay = SpaceLength::new(1_000);
-        let p = Problem::new(vessels, entries, quay);
-        assert!(p.is_ok());
+        assert!(Problem::new(vessels, maints, entries, quay).is_ok());
+    }
+
+    #[test]
+    fn test_err_overlap_in_time_and_space() {
+        let vessels = hs([
+            vessel::<i64>(1, 150, 10, 0, 0, window(0, 1_000)),
+            vessel::<i64>(2, 150, 10, 0, 0, window(0, 1_000)),
+        ]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(1),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(0),
+            }),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(2),
+                berthing_position: SpacePosition::new(200),
+                berthing_time: TimePoint::new(0),
+            }),
+        ]);
+        let quay = SpaceLength::new(1_000);
+        let err = Problem::new(vessels, maints, entries, quay).unwrap_err();
+        matches!(err, ProblemError::OccupancyOverlap(_));
+    }
+
+    #[test]
+    fn test_ok_overlap_in_time_only() {
+        let vessels = hs([
+            vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000)),
+            vessel::<i64>(2, 100, 10, 0, 0, window(0, 1_000)),
+        ]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(1),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(0),
+            }),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(2),
+                berthing_position: SpacePosition::new(400),
+                berthing_time: TimePoint::new(5),
+            }),
+        ]);
+        let quay = SpaceLength::new(1_000);
+        assert!(Problem::new(vessels, maints, entries, quay).is_ok());
+    }
+
+    #[test]
+    fn test_ok_overlap_in_space_only() {
+        let vessels = hs([
+            vessel::<i64>(1, 100, 10, 0, 0, window(0, 1_000)),
+            vessel::<i64>(2, 100, 10, 0, 0, window(0, 1_000)),
+        ]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(1),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(0),
+            }),
+            OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+                vessel_id: VesselId::new(2),
+                berthing_position: SpacePosition::new(100),
+                berthing_time: TimePoint::new(10),
+            }),
+        ]);
+        let quay = SpaceLength::new(1_000);
+        assert!(Problem::new(vessels, maints, entries, quay).is_ok());
+    }
+
+    #[test]
+    fn test_ok_maintenance_within_feasible_window() {
+        let vessels = hs([vessel::<i64>(1, 80, 10, 0, 0, window(0, 1_000))]);
+        let maints = hs([MaintenanceSpec::new(
+            MaintenanceId::new(9),
+            SpacePosition::new(500),
+            SpaceLength::new(50),
+            TimeDelta::new(4),
+            TimeInterval::new(TimePoint::new(0), TimePoint::new(20)),
+        )]);
+        let entries = hs([OccupancyEntry::PreAssigned(
+            OccupancyAssignment::Maintenance {
+                id: MaintenanceId::new(9),
+                start_time: TimePoint::new(10), // ends at 14, within [0,20)
+            },
+        )]);
+        let quay = SpaceLength::new(1_000);
+        assert!(Problem::new(vessels, maints, entries, quay).is_ok());
+    }
+
+    #[test]
+    fn test_err_maintenance_outside_feasible_window() {
+        let vessels = hs([vessel::<i64>(1, 80, 10, 0, 0, window(0, 1_000))]);
+        let maints = hs([MaintenanceSpec::new(
+            MaintenanceId::new(9),
+            SpacePosition::new(500),
+            SpaceLength::new(50),
+            TimeDelta::new(4),
+            TimeInterval::new(TimePoint::new(0), TimePoint::new(12)),
+        )]);
+        let entries = hs([OccupancyEntry::PreAssigned(
+            OccupancyAssignment::Maintenance {
+                id: MaintenanceId::new(9),
+                start_time: TimePoint::new(10), // would end at 14 > 12
+            },
+        )]);
+        let quay = SpaceLength::new(1_000);
+        let err = Problem::new(vessels, maints, entries, quay).unwrap_err();
+        matches!(err, ProblemError::MaintenanceOutsideFeasibleTime(_));
+    }
+
+    #[test]
+    fn test_err_vessel_assigned_before_arrival() {
+        let vessels = hs([vessel::<i64>(1, 100, 10, 5, 0, window(0, 1_000))]);
+        let maints: HashSet<MaintenanceSpec<i64>> = HashSet::new();
+        let entries = hs([OccupancyEntry::PreAssigned(OccupancyAssignment::Vessel {
+            vessel_id: VesselId::new(1),
+            berthing_position: SpacePosition::new(100),
+            berthing_time: TimePoint::new(3), // before arrival
+        })]);
+        let quay = SpaceLength::new(1_000);
+        let err = Problem::new(vessels, maints, entries, quay).unwrap_err();
+        matches!(err, ProblemError::VesselAssignedBeforeArrival(_));
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and additions to the `dock-alloc-core` crate and the overall workspace. The most significant changes are the addition of new interval manipulation methods, enhanced documentation, and the introduction of a new crate for modeling. Additionally, the test suite has been refactored for clarity and consistency.

**Core library enhancements:**

* Added three new methods to the `Interval<T>` type: `translate`, `inflate`, and `measure`, allowing intervals to be shifted, expanded, and measured, respectively. Each method includes inline documentation and usage examples.
* Improved crate-level documentation in `lib.rs` to provide a clear overview of the library's purpose, core modules, and design philosophy.
* Added a comprehensive `README.md` for `dock-alloc-core`, detailing its domain concepts, features, and usage examples.

**Testing improvements:**

* Refactored all test function names in `primitives.rs` to follow the `test_*` naming convention, improving clarity and consistency. [[1]](diffhunk://#diff-676c6b2f55c947f3eeb06544ef86ff33d0589d91ef22b1bb7c522cbeeebcb3bcL573-R679) [[2]](diffhunk://#diff-676c6b2f55c947f3eeb06544ef86ff33d0589d91ef22b1bb7c522cbeeebcb3bcL620-R696) [[3]](diffhunk://#diff-676c6b2f55c947f3eeb06544ef86ff33d0589d91ef22b1bb7c522cbeeebcb3bcL637-R742) [[4]](diffhunk://#diff-676c6b2f55c947f3eeb06544ef86ff33d0589d91ef22b1bb7c522cbeeebcb3bcL683-R871) [[5]](diffhunk://#diff-676c6b2f55c947f3eeb06544ef86ff33d0589d91ef22b1bb7c522cbeeebcb3bcL812-R880) [[6]](diffhunk://#diff-676c6b2f55c947f3eeb06544ef86ff33d0589d91ef22b1bb7c522cbeeebcb3bcL821-R936)

**Workspace and project structure:**

* Added the new `dock-alloc-model` crate to the workspace and included its own `Cargo.toml` with dependencies and license header, laying the foundation for higher-level modeling based on the core primitives. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L24-R24) [[2]](diffhunk://#diff-3ba439e39a5df7a7df82a20f44eedf4d835899e9e628427e5d0ad2b5f3a80b06R1-R29)