### PR TITLE
Simplify and clean up Rust setup script for Runpod

### DIFF
--- a/setup_runpod.sh
+++ b/setup_runpod.sh
@@ -1,21 +1,13 @@
 #!/usr/bin/env bash
-# setup_rust_runpod.sh
+# setup_rust_runpod_clean.sh
 # Sets up Rust in a plain Runpod Ubuntu container.
-# - Updates packages; installs build tools, Git, Curl
-# - Installs rustup (non-interactive), rustc, cargo
-# - Persists PATH
-# - (Optional) relocates CARGO_HOME/RUSTUP_HOME to /workspace for persistent caches
+# - Updates packages; installs base build tools
+# - Ensures git (if missing), clang (if missing), cmake (if missing)
+# - Installs rustup (non-interactive), rustc, cargo, rustfmt, clippy
 # - Verifies installation
 # Idempotent: safe to run multiple times.
 
 set -euo pipefail
-
-### Configuration ################################################################
-# If true and /workspace exists, store Cargo/Rustup under /workspace (persistent).
-PERSIST_TO_WORKSPACE=true
-# Extra tools you may want:
-INSTALL_CLANG_AND_CMAKE=true
-##################################################################################
 
 # Use sudo only if not running as root
 if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
@@ -24,70 +16,40 @@ else
   SUDO=""
 fi
 
-echo "==> Updating package lists & installing base tools..."
+echo "==> Updating package lists & upgrading..."
 $SUDO apt-get update -y
 $SUDO apt-get upgrade -y
 
-PKGS=(ca-certificates curl build-essential pkg-config libssl-dev)
-[[ "$INSTALL_CLANG_AND_CMAKE" == "true" ]] && PKGS+=(clang cmake)
+# Base build tools (installed regardless; harmless if already present)
+BASE_PKGS=(ca-certificates curl build-essential pkg-config libssl-dev)
 
-# Install Git only if missing
-if ! command -v git >/dev/null 2>&1; then
-  PKGS+=(git)
-fi
+# Conditionally add tools only if missing
+EXTRA_PKGS=()
+if ! command -v git >/dev/null 2>&1;   then EXTRA_PKGS+=(git);   fi
+if ! command -v clang >/dev/null 2>&1; then EXTRA_PKGS+=(clang); fi
+if ! command -v cmake >/dev/null 2>&1; then EXTRA_PKGS+=(cmake); fi
 
-$SUDO apt-get install -y --no-install-recommends "${PKGS[@]}"
+echo "==> Installing required packages..."
+$SUDO apt-get install -y --no-install-recommends "${BASE_PKGS[@]}" "${EXTRA_PKGS[@]}"
 $SUDO apt-get autoremove -y
 $SUDO apt-get clean
 
 # Install rustup if missing
 if ! command -v rustup >/dev/null 2>&1; then
   echo "==> Installing rustup (non-interactive)..."
-  # Default profile: installs rustc, cargo, rustup (stable)
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 else
   echo "==> rustup already present — skipping install."
 fi
 
-# Activate PATH in current shell
+# Activate PATH for current shell session (no shell rc writes)
 if [[ -f "$HOME/.cargo/env" ]]; then
   # shellcheck disable=SC1090
   source "$HOME/.cargo/env"
 fi
 
-# Optional: persist Cargo/Rustup to /workspace
-if [[ "$PERSIST_TO_WORKSPACE" == "true" && -d "/workspace" ]]; then
-  echo "==> Relocating Cargo/Rustup to /workspace (persistent caches)..."
-  CARGO_HOME_TARGET="/workspace/.cargo"
-  RUSTUP_HOME_TARGET="/workspace/.rustup"
-
-  mkdir -p "$CARGO_HOME_TARGET" "$RUSTUP_HOME_TARGET"
-
-  # Move current contents if they exist (and are not symlinks)
-  if [[ -d "$HOME/.cargo" && ! -L "$HOME/.cargo" ]]; then
-    rsync -a --delete "$HOME/.cargo/" "$CARGO_HOME_TARGET/" || true
-    rm -rf "$HOME/.cargo"
-  fi
-  if [[ -d "$HOME/.rustup" && ! -L "$HOME/.rustup" ]]; then
-    rsync -a --delete "$HOME/.rustup/" "$RUSTUP_HOME_TARGET/" || true
-    rm -rf "$HOME/.rustup"
-  fi
-
-  # Symlink into $HOME
-  ln -sfn "$CARGO_HOME_TARGET" "$HOME/.cargo"
-  ln -sfn "$RUSTUP_HOME_TARGET" "$HOME/.rustup"
-fi
-
-# Persist PATH (if not already present)
-if ! grep -q 'export PATH="$HOME/.cargo/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
-  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.bashrc"
-fi
-if [[ -f "$HOME/.profile" ]] && ! grep -q 'export PATH="$HOME/.cargo/bin:$PATH"' "$HOME/.profile"; then
-  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.profile"
-fi
-
-# Components (idempotent)
-echo "==> Installing/updating Rust components (rustfmt, clippy)..."
+# Ensure stable toolchain and components
+echo "==> Ensuring stable toolchain + components..."
 rustup toolchain install stable -q || true
 rustup default stable -q || true
 rustup component add rustfmt clippy -q || true
@@ -98,24 +60,10 @@ set +e
 rustc --version
 cargo --version
 rustup --version
+clang --version 2>/dev/null | head -n1
+cmake --version 2>/dev/null | head -n1
+git --version 2>/dev/null
 set -e
 
-# Optional mini build test
-if [[ -w "/workspace" ]]; then
-  TEST_DIR="/workspace/_rust_ok"
-else
-  TEST_DIR="$HOME/_rust_ok"
-fi
-if [[ ! -d "$TEST_DIR" ]]; then
-  mkdir -p "$TEST_DIR"
-  pushd "$TEST_DIR" >/dev/null
-  cargo new --bin hello_world >/dev/null 2>&1 || true
-  pushd hello_world >/dev/null
-  echo 'fn main(){ println!("Rust OK"); }' > src/main.rs
-  cargo build --quiet || true
-  popd >/dev/null
-  popd >/dev/null
-fi
-
 echo "==> Done. Rust is installed and configured."
-echo "    Start a new shell or: source \$HOME/.cargo/env"
+echo "    For new shells: source \"$HOME/.cargo/env\""

--- a/setup_runpod.sh
+++ b/setup_runpod.sh
@@ -62,7 +62,7 @@ cargo --version
 rustup --version
 clang --version 2>/dev/null | head -n1
 cmake --version 2>/dev/null | head -n1
-git --version 2>/dev/null
+git --version 2>/dev/null | head -n1
 set -e
 
 echo "==> Done. Rust is installed and configured."


### PR DESCRIPTION
This pull request refactors the `setup_runpod.sh` script to simplify Rust environment setup in a Runpod Ubuntu container, focusing on base tool installation, idempotency, and clarity. It removes optional workspace persistence and configuration flags, ensures only missing tools are installed, and improves verification output.

**Tool installation and environment setup:**

* The script now only installs base build tools and conditionally adds `git`, `clang`, and `cmake` if they are missing, rather than always installing or relying on configuration flags.
* Removes logic for relocating `CARGO_HOME` and `RUSTUP_HOME` to `/workspace`, simplifying the installation and avoiding persistent cache management.
* Removes code that would persist the Rust toolchain path to shell rc/profile files, instead instructing users to source the environment file manually for new shells.

**Verification and output improvements:**

* Adds explicit version checks for `clang`, `cmake`, and `git` in the verification step to confirm installation.
* Removes the optional mini build test, further streamlining the script and focusing on tool installation.
* Updates completion message for clarity, instructing users to source the Rust environment file for new shells.