### PR TITLE
Rename _p to _phantom in operator structs

### DIFF
--- a/crates/dock-alloc-solver/src/meta/oplib/bandrepack.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/bandrepack.rs
@@ -30,7 +30,7 @@ use rand_chacha::ChaCha8Rng;
 
 pub struct BandRepackOperator<T, C, Q> {
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for BandRepackOperator<T, C, Q>
@@ -42,7 +42,7 @@ where
     fn default() -> Self {
         Self {
             attempts: 8,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/blockshift.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/blockshift.rs
@@ -31,7 +31,7 @@ use rand_chacha::ChaCha8Rng;
 pub struct BlockShiftOperator<T, C, Q> {
     pub max_block: usize,
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for BlockShiftOperator<T, C, Q>
@@ -44,7 +44,7 @@ where
         Self {
             max_block: 4,
             attempts: 16,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/cascaderelocate.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/cascaderelocate.rs
@@ -34,7 +34,7 @@ use rand_chacha::ChaCha8Rng;
 pub struct CascadeRelocateOperator<T, C, Q> {
     pub attempts: usize,
     pub max_group: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for CascadeRelocateOperator<T, C, Q>
@@ -47,7 +47,7 @@ where
         Self {
             attempts: 16,
             max_group: 6,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/crossinsert.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/crossinsert.rs
@@ -30,7 +30,7 @@ use rand_chacha::ChaCha8Rng;
 
 pub struct CrossInsertOperator<T, C, Q> {
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for CrossInsertOperator<T, C, Q>
@@ -42,7 +42,7 @@ where
     fn default() -> Self {
         Self {
             attempts: 32,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/exchangetime.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/exchangetime.rs
@@ -29,9 +29,8 @@ use rand::seq::IteratorRandom;
 use rand_chacha::ChaCha8Rng;
 
 pub struct TwoExchangeTimeOperator<T, C, Q> {
-    /// How many random pairs to try per call.
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for TwoExchangeTimeOperator<T, C, Q>
@@ -43,7 +42,7 @@ where
     fn default() -> Self {
         Self {
             attempts: 32,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/latepenalty.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/latepenalty.rs
@@ -37,7 +37,7 @@ where
     Q: QuayRead,
 {
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for LatePenaltyFocusOperator<T, C, Q>
@@ -49,7 +49,7 @@ where
     fn default() -> Self {
         Self {
             attempts: 8,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/neighborhoodruinrecreate.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/neighborhoodruinrecreate.rs
@@ -42,7 +42,7 @@ where
     pub space_radius: SpaceLength,
     pub attempts: usize,
     pub shuffle_recreate: bool,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for NeighborhoodRuinRecreateOperator<T, C, Q>
@@ -57,7 +57,7 @@ where
             space_radius: SpaceLength::new(0),
             attempts: 8,
             shuffle_recreate: true,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/pairswap.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/pairswap.rs
@@ -43,7 +43,7 @@ where
 {
     pub attempts: usize,
     pub lateral_slack: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for PairSwapBandOperator<T, C, Q>
@@ -56,7 +56,7 @@ where
         Self {
             attempts: 32,
             lateral_slack: 4,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/push.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/push.rs
@@ -34,7 +34,7 @@ use rand_chacha::ChaCha8Rng;
 
 pub struct PushBackOperator<T, C, Q> {
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for PushBackOperator<T, C, Q>
@@ -46,7 +46,7 @@ where
     fn default() -> Self {
         Self {
             attempts: 16,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/spaceshift.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/spaceshift.rs
@@ -35,7 +35,7 @@ use rand_chacha::ChaCha8Rng;
 pub struct SpaceShiftOperator<T, C, Q> {
     pub max_shift: usize,
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T, C, Q> Default for SpaceShiftOperator<T, C, Q>
@@ -48,7 +48,7 @@ where
         Self {
             max_shift: 5,
             attempts: 16,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/crates/dock-alloc-solver/src/meta/oplib/swap.rs
+++ b/crates/dock-alloc-solver/src/meta/oplib/swap.rs
@@ -29,7 +29,7 @@ use rand::seq::IteratorRandom;
 
 pub struct SwapOperator<T, C, Q> {
     pub attempts: usize,
-    _p: core::marker::PhantomData<(T, C, Q)>,
+    _phantom: core::marker::PhantomData<(T, C, Q)>,
 }
 
 impl<T: SolverVariable, C: SolverVariable + TryFrom<T> + TryFrom<usize>, Q: QuayRead + Send + Sync>
@@ -38,7 +38,7 @@ impl<T: SolverVariable, C: SolverVariable + TryFrom<T> + TryFrom<usize>, Q: Quay
     fn default() -> Self {
         Self {
             attempts: 32,
-            _p: core::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/setup_runpod.sh
+++ b/setup_runpod.sh
@@ -48,6 +48,14 @@ if [[ -f "$HOME/.cargo/env" ]]; then
   source "$HOME/.cargo/env"
 fi
 
+# Ensure ~/.cargo/bin is permanently on PATH (idempotent)
+if ! grep -q 'export PATH="$HOME/.cargo/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.bashrc"
+fi
+if [[ -f "$HOME/.profile" ]] && ! grep -q 'export PATH="$HOME/.cargo/bin:$PATH"' "$HOME/.profile"; then
+  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.profile"
+fi
+
 # Ensure stable toolchain and components
 echo "==> Ensuring stable toolchain + components..."
 rustup toolchain install stable -q || true


### PR DESCRIPTION
This pull request primarily refactors the internal naming for phantom type markers across multiple operator structs in the `dock-alloc-solver` crate, improving code clarity and consistency. It also introduces a significant rewrite of the core logic for the `WindowTightenOperator`, streamlining its operational flow and error handling. Additionally, a copyright/license header is added to the `windowtighten.rs` file, and the setup script is enhanced to ensure the Rust binary path is correctly set.